### PR TITLE
Feature: Update TrackingProvider and TrackingContext to allow for structured data

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,39 +36,39 @@ const {TrackingProvider, TrackingContext} = require('@vrbo/react-event-tracking'
 const {TrackingProvider, TrackingContext} = require('@vrbo/react-event-tracking');
 ```
 
-Applications use a `TrackingProvider` to define the event triggering implementation and wrap components that trigger events with additional analytics and options that will be merged into the triggered event.
+Applications use a `TrackingProvider` to define the event triggering implementation and wrap components that trigger events with additional payload and options that will be merged into the triggered event.
 
-Components make use of `TrackingContext` or `TrackingTrigger` to trigger events which will automatically merge the analytics and options specified at higher levels in the DOM through one or more `TrackingProvider` components.
+Components make use of `TrackingContext` or `TrackingTrigger` to trigger events which will automatically merge the payload and options specified at higher levels in the DOM through one or more `TrackingProvider` components.
 
 ### TrackingProvider
 
-The `TrackingProvider` is a [React 16 context provider](https://reactjs.org/docs/context.html) component that allows an application to define the event trigger implementation and incrementally build the analytics and options for analytic events that will trigger from nested components. Using the `TrackingProvider` enables components at the lowest level to trigger events with the necessary set of analytics and options. The `TrackingProvider` is intended as a generic provider that does not require the use of a specific analytic event tracking library.
+The `TrackingProvider` is a [React 16 context provider](https://reactjs.org/docs/context.html) component that allows an application to define the event trigger implementation and incrementally build the payload and options for analytic events that will trigger from nested components. Using the `TrackingProvider` enables components at the lowest level to trigger events with the necessary set of payload and options. The `TrackingProvider` is intended as a generic provider that does not require the use of a specific analytic event tracking library.
 
 > Note: It is strongly recommended that property values for the TrackingProvider be defined in state or constant variables instead of building the values dynamically on every render. If the values are constructed during the render, it will cause a FORCE RE-RENDER of ALL consumers of the context that are descendants of the provider, even if the consumer's shouldComponentUpdate bails out. Following a pattern of defining property values as constants or via state will prevent unnecessary renders of children context consumers.
 
 | PROPERTY       | TYPE                | DEFAULT  | DESCRIPTION |
 | -------------- | ------------------- | -------- | ----------- |
-| eventAnalytics | objectOf (objectOf) | ──       | An object of event specific analytics where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `analytics` property. |
+| eventPayload   | objectOf (objectOf) | ──       | An object of event specific payload where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `payload` property. |
 | eventOptions   | objectOf (objectOf) | ──       | An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. |
-| analytics      | objectOf (any)      | ──       | Object of any values that represents the default analytics to apply to all events within this context. |
+| payload        | objectOf (any)      | ──       | Object of any values that represents the default payload to apply to all events within this context. |
 | options        | objectOf (any)      | ──       | The trigger options. |
 | overwrite      | bool                | false    | When true, overwrites the current context with specified properties. Default is to merge instead of overwrite. |
 | trigger        | func                | () => {} | Tracking event trigger implementation. |
 
-In the example below the `Calendar` component is known to trigger some events so the consuming application wraps it with a `TrackingProvider` and the appropriate configuration of analytics and options as well as the implementation of `trigger` appropriate for the application.
+In the example below the `Calendar` component is known to trigger some events so the consuming application wraps it with a `TrackingProvider` and the appropriate configuration of payload and options as well as the implementation of `trigger` appropriate for the application.
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const defaultAnalytics = {location: 'top-right'};
+const defaultPayload = {location: 'top-right'};
 const defaultOptions = {asynchronous: true};
-const customTrigger = (event, analytics, options) => {
+const customTrigger = (event, payload, options) => {
     // Implement custom event tracking.
 }
 
 function App(props) {
     return (
         <TrackingProvider
-            analytics={defaultAnalytics}
+            payload={defaultPayload}
             options={defaultOptions}
             trigger={customTrigger}
         >
@@ -84,7 +84,7 @@ For further details on usage of the `TrackingProvider` component view the [compo
 
 ### TrackingContext
 
-While the `TrackingProvider` component is used to incrementally build the analytics and options for an event and define the trigger implementation, the `TrackingContext` module is used to trigger the analytic event. Structuring a component to use `TrackingContext` will provide access to the `trigger` method to trigger analytic events via `this.context.trigger`.
+While the `TrackingProvider` component is used to incrementally build the payload and options for an event and define the trigger implementation, the `TrackingContext` module is used to trigger the analytic event. Structuring a component to use `TrackingContext` will provide access to the `trigger` method to trigger analytic events via `this.context.trigger`.
 
 In the example below, `MyComponent` is configured to use the `TrackingContext` module and then triggers a `generic.click` event when the `handleClick()` method is invoked:
 
@@ -105,31 +105,31 @@ class MyComponent extends React.Component {
 The trigger API has the following signature:
 
 ```javascript
-trigger(event, analytics, options)
+trigger(event, payload, options)
 ```
 
 Where:
 
 * event - The name of the event to trigger (String)
-* analytics - The required and optional analytics for the event (Object).
+* payload - The required and optional payload for the event (Object).
 * options - The trigger options to use when triggering the event (Object)
 
 For further details on usage of the `TrackingContext` module view the [module documentation](markdown/TrackingContext.md).
 
 ### TrackingTrigger
 
-The `TrackingTrigger` component allows an application to declaratively trigger an analytic event. It is used in conjunction with the `TrackingProvider` component to trigger events in a standardized way. Specify the desired event name, analytics and options to include when the event is triggered. The event will be triggered with a merge of the specified analytics and options and the current context when the containing component’s `componentDidMount` is invoked.
+The `TrackingTrigger` component allows an application to declaratively trigger an analytic event. It is used in conjunction with the `TrackingProvider` component to trigger events in a standardized way. Specify the desired event name, payload and options to include when the event is triggered. The event will be triggered with a merge of the specified payload and options and the current context when the containing component’s `componentDidMount` is invoked.
 
 | PROPERTY     | TYPE                | DEFAULT  | DESCRIPTION |
 | ------------ | ------------------- | -------- | ----------- |
 | event        | string              | ──       | The event to trigger |
-| analytics    | objectOf (any)      | {}       | The event specific analytics |
+| payload      | objectOf (any)      | {}       | The event specific payload |
 | onTrigger    | func                | () => {} | Callback function invoked after the event successfully triggered. |
 | options      | objectOf (any)      | {}       | The trigger options. |
 
 ```jsx
 import {TrackingTrigger} from '@vrbo/react-event-tracking';
-const eventAnalytics = {
+const eventPayload = {
     location: 'searchbar',
     name: 'Calendar'
 };
@@ -140,7 +140,7 @@ function Calendar(props) {
         ...
         <TrackingTrigger
             event={'viewed'}
-            analytics={eventAnalytics}
+            payload={eventPayload}
             options={eventOptions}
         />
     );

--- a/README.md
+++ b/README.md
@@ -36,39 +36,39 @@ const {TrackingProvider, TrackingContext} = require('@vrbo/react-event-tracking'
 const {TrackingProvider, TrackingContext} = require('@vrbo/react-event-tracking');
 ```
 
-Applications use a `TrackingProvider` to define the event triggering implementation and wrap components that trigger events with additional fields and options that will be merged into the triggered event.
+Applications use a `TrackingProvider` to define the event triggering implementation and wrap components that trigger events with additional analytics and options that will be merged into the triggered event.
 
-Components make use of `TrackingContext` or `TrackingTrigger` to trigger events which will automatically merge the fields and options specified at higher levels in the DOM through one or more `TrackingProvider` components.
+Components make use of `TrackingContext` or `TrackingTrigger` to trigger events which will automatically merge the analytics and options specified at higher levels in the DOM through one or more `TrackingProvider` components.
 
 ### TrackingProvider
 
-The `TrackingProvider` is a [React 16 context provider](https://reactjs.org/docs/context.html) component that allows an application to define the event trigger implementation and incrementally build the fields and options for analytic events that will trigger from nested components. Using the `TrackingProvider` enables components at the lowest level to trigger events with the necessary set of fields and options. The `TrackingProvider` is intended as a generic provider that does not require the use of a specific analytic event tracking library.
+The `TrackingProvider` is a [React 16 context provider](https://reactjs.org/docs/context.html) component that allows an application to define the event trigger implementation and incrementally build the analytics and options for analytic events that will trigger from nested components. Using the `TrackingProvider` enables components at the lowest level to trigger events with the necessary set of analytics and options. The `TrackingProvider` is intended as a generic provider that does not require the use of a specific analytic event tracking library.
 
 > Note: It is strongly recommended that property values for the TrackingProvider be defined in state or constant variables instead of building the values dynamically on every render. If the values are constructed during the render, it will cause a FORCE RE-RENDER of ALL consumers of the context that are descendants of the provider, even if the consumer's shouldComponentUpdate bails out. Following a pattern of defining property values as constants or via state will prevent unnecessary renders of children context consumers.
 
-| PROPERTY     | TYPE                | DEFAULT  | DESCRIPTION |
-| ------------ | ------------------- | -------- | ----------- |
-| eventFields  | objectOf (objectOf) | ──       | An object of event specific fields where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `fields` property. |
-| eventOptions | objectOf (objectOf) | ──       | An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. |
-| fields       | objectOf (string)   | ──       | Object of string values that represents the default fields to apply to all events within this context. |
-| options      | objectOf (string)   | ──       | The trigger options. |
-| overwrite    | bool                | false    | When true, overwrites the current context with specified properties. Default is to merge instead of overwrite. |
-| trigger      | func                | () => {} | Tracking event trigger implementation. |
+| PROPERTY       | TYPE                | DEFAULT  | DESCRIPTION |
+| -------------- | ------------------- | -------- | ----------- |
+| eventAnalytics | objectOf (objectOf) | ──       | An object of event specific analytics where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `analytics` property. |
+| eventOptions   | objectOf (objectOf) | ──       | An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. |
+| analytics      | objectOf (any)      | ──       | Object of any values that represents the default analytics to apply to all events within this context. |
+| options        | objectOf (any)      | ──       | The trigger options. |
+| overwrite      | bool                | false    | When true, overwrites the current context with specified properties. Default is to merge instead of overwrite. |
+| trigger        | func                | () => {} | Tracking event trigger implementation. |
 
-In the example below the `Calendar` component is known to trigger some events so the consuming application wraps it with a `TrackingProvider` and the appropriate configuration of fields and options as well as the implementation of `trigger` appropriate for the application.
+In the example below the `Calendar` component is known to trigger some events so the consuming application wraps it with a `TrackingProvider` and the appropriate configuration of analytics and options as well as the implementation of `trigger` appropriate for the application.
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const defaultFields = {location: 'top-right'};
+const defaultAnalytics = {location: 'top-right'};
 const defaultOptions = {asynchronous: true};
-const customTrigger = (event, fields, options) => {
+const customTrigger = (event, analytics, options) => {
     // Implement custom event tracking.
 }
 
 function App(props) {
     return (
         <TrackingProvider
-            fields={defaultFields}
+            analytics={defaultAnalytics}
             options={defaultOptions}
             trigger={customTrigger}
         >
@@ -84,7 +84,7 @@ For further details on usage of the `TrackingProvider` component view the [compo
 
 ### TrackingContext
 
-While the `TrackingProvider` component is used to incrementally build the fields and options for an event and define the trigger implementation, the `TrackingContext` module is used to trigger the analytic event. Structuring a component to use `TrackingContext` will provide access to the `trigger` method to trigger analytic events via `this.context.trigger`.
+While the `TrackingProvider` component is used to incrementally build the analytics and options for an event and define the trigger implementation, the `TrackingContext` module is used to trigger the analytic event. Structuring a component to use `TrackingContext` will provide access to the `trigger` method to trigger analytic events via `this.context.trigger`.
 
 In the example below, `MyComponent` is configured to use the `TrackingContext` module and then triggers a `generic.click` event when the `handleClick()` method is invoked:
 
@@ -105,31 +105,31 @@ class MyComponent extends React.Component {
 The trigger API has the following signature:
 
 ```javascript
-trigger(event, fields, options)
+trigger(event, analytics, options)
 ```
 
 Where:
 
 * event - The name of the event to trigger (String)
-* fields - The required and optional fields for the event (Object of string values).
+* analytics - The required and optional analytics for the event (Object).
 * options - The trigger options to use when triggering the event (Object)
 
 For further details on usage of the `TrackingContext` module view the [module documentation](markdown/TrackingContext.md).
 
 ### TrackingTrigger
 
-The `TrackingTrigger` component allows an application to declaratively trigger an analytic event. It is used in conjunction with the `TrackingProvider` component to trigger events in a standardized way. Specify the desired event name, fields and options to include when the event is triggered. The event will be triggered with a merge of the specified fields and options and the current context when the containing component’s `componentDidMount` is invoked.
+The `TrackingTrigger` component allows an application to declaratively trigger an analytic event. It is used in conjunction with the `TrackingProvider` component to trigger events in a standardized way. Specify the desired event name, analytics and options to include when the event is triggered. The event will be triggered with a merge of the specified analytics and options and the current context when the containing component’s `componentDidMount` is invoked.
 
 | PROPERTY     | TYPE                | DEFAULT  | DESCRIPTION |
 | ------------ | ------------------- | -------- | ----------- |
 | event        | string              | ──       | The event to trigger |
-| fields       | objectOf (string)   | {}       | The event specific fields |
+| analytics    | objectOf (any)      | {}       | The event specific analytics |
 | onTrigger    | func                | () => {} | Callback function invoked after the event successfully triggered. |
-| options      | objectOf (string)   | {}       | The trigger options. |
+| options      | objectOf (any)      | {}       | The trigger options. |
 
 ```jsx
 import {TrackingTrigger} from '@vrbo/react-event-tracking';
-const eventFields = {
+const eventAnalytics = {
     location: 'searchbar',
     name: 'Calendar'
 };
@@ -140,7 +140,7 @@ function Calendar(props) {
         ...
         <TrackingTrigger
             event={'viewed'}
-            fields={eventFields}
+            analytics={eventAnalytics}
             options={eventOptions}
         />
     );

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ The `TrackingProvider` is a [React 16 context provider](https://reactjs.org/docs
 | PROPERTY       | TYPE                | DEFAULT  | DESCRIPTION |
 | -------------- | ------------------- | -------- | ----------- |
 | eventPayload   | objectOf (objectOf) | ──       | An object of event specific payload where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `payload` property. |
+| eventFields    | objectOf (objectOf) | ──       | (Deprecated) An object of event specific fields where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `fields` property. |
 | eventOptions   | objectOf (objectOf) | ──       | An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. |
 | payload        | objectOf (any)      | ──       | Object of any values that represents the default payload to apply to all events within this context. |
+| fields         | objectOf (string)   | ──       | (Deprecated) Object of string values that represents the default fields to apply to all events within this context. |
 | options        | objectOf (any)      | ──       | The trigger options. |
 | overwrite      | bool                | false    | When true, overwrites the current context with specified properties. Default is to merge instead of overwrite. |
 | trigger        | func                | () => {} | Tracking event trigger implementation. |
@@ -155,6 +157,7 @@ For further details on usage of the `TrackingTrigger` component view the [compon
 * Prior to React 16.8.0 it was not possible for a component to use multiple `contextType` definitions. If a component needs to consume multiple `contextType` definitions, use the [hooks api](https://reactjs.org/docs/hooks-overview.html#other-hooks) made available in React 16.8.0.
 * If a `TrackingProvider` with a `trigger` implementation is not defined somewhere in the hierarchy, the `this.context.trigger` API will essentially be a no-op. This allows components to be enabled to trigger events regardless of whether the application is configured to trigger them.
 * Do not dynamically construct the property values for `TrackingProvider` unless you want all descendant consumers to force re-render. See the "Note" under the `TrackingProvider` section for more details.
+* Objects used in `eventPayload` and `eventOptions` are shallow copied, so changes to referenced objects would be reflected in all usages. Use new objects to avoid this.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ The `TrackingProvider` is a [React 16 context provider](https://reactjs.org/docs
 | PROPERTY       | TYPE                | DEFAULT  | DESCRIPTION |
 | -------------- | ------------------- | -------- | ----------- |
 | eventPayload   | objectOf (objectOf) | ──       | An object of event specific payload where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `payload` property. |
-| eventFields    | objectOf (objectOf) | ──       | (Deprecated) An object of event specific fields where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `fields` property. |
+| eventFields    | objectOf (objectOf) | ──       | (Deprecated) An object of event specific fields where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `fields` property. The `eventPayload` property takes precedence over this property if both are specified. |
 | eventOptions   | objectOf (objectOf) | ──       | An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. |
 | payload        | objectOf (any)      | ──       | Object of any values that represents the default payload to apply to all events within this context. |
-| fields         | objectOf (string)   | ──       | (Deprecated) Object of string values that represents the default fields to apply to all events within this context. |
+| fields         | objectOf (string)   | ──       | (Deprecated) Object of string values that represents the default fields to apply to all events within this context. The `payload` property takes precedence over this property if both are specified.  |
 | options        | objectOf (any)      | ──       | The trigger options. |
 | overwrite      | bool                | false    | When true, overwrites the current context with specified properties. Default is to merge instead of overwrite. |
 | trigger        | func                | () => {} | Tracking event trigger implementation. |
@@ -157,7 +157,7 @@ For further details on usage of the `TrackingTrigger` component view the [compon
 * Prior to React 16.8.0 it was not possible for a component to use multiple `contextType` definitions. If a component needs to consume multiple `contextType` definitions, use the [hooks api](https://reactjs.org/docs/hooks-overview.html#other-hooks) made available in React 16.8.0.
 * If a `TrackingProvider` with a `trigger` implementation is not defined somewhere in the hierarchy, the `this.context.trigger` API will essentially be a no-op. This allows components to be enabled to trigger events regardless of whether the application is configured to trigger them.
 * Do not dynamically construct the property values for `TrackingProvider` unless you want all descendant consumers to force re-render. See the "Note" under the `TrackingProvider` section for more details.
-* Objects used in `eventPayload` and `eventOptions` are shallow copied, so changes to referenced objects would be reflected in all usages. Use new objects to avoid this.
+* Objects used in `eventPayload`, `eventOptions` and `payload` are shallow copied when merging data in the `TrackingProvider`, so changes to referenced objects would be reflected in all usages. Use new objects to avoid this.
 
 ## Development
 

--- a/markdown/TrackingContext.md
+++ b/markdown/TrackingContext.md
@@ -1,10 +1,10 @@
-`TrackingContext` provides acccess to the current value of the context defined by a `TrackingProvider`. Use of `TrackingProvider` and `TrackingContext` enables an application to progressively build the fields and options and then trigger events at the lowest level.
+`TrackingContext` provides acccess to the current value of the context defined by a `TrackingProvider`. Use of `TrackingProvider` and `TrackingContext` enables an application to progressively build the analytics and options and then trigger events at the lowest level.
 
 ## Base Usage
 
 Structuring a component to use `TrackingContext` will provide access to the `trigger` method to trigger events. Use one of the two methods shown below to configure the context for a React component. Once configured as shown, the component can then access the `trigger` method via `this.context.trigger`.
 
-If the babel configuration for the application includes support for [public class fields syntax](https://babeljs.io/docs/plugins/transform-class-properties/) and the application is using **react ^16.6.0**, use a *static* class field to initialize the `contextType`:
+If the babel configuration for the application includes support for [public class analytics syntax](https://babeljs.io/docs/plugins/transform-class-properties/) and the application is using **react ^16.6.0**, use a *static* class field to initialize the `contextType`:
 
 ```jsx
 import React, {Component} from 'react';
@@ -20,7 +20,7 @@ class MyComponent extends Component {
 }
 ```
 
-Alternatively, if a component is not using public class fields syntax, set the `contextType` directly on the class:
+Alternatively, if a component is not using public class analytics syntax, set the `contextType` directly on the class:
 
 ```jsx
 import React, {Component} from 'react';
@@ -37,18 +37,18 @@ MyComponent.contextType = TrackingContext;
 
 ## Trigger API
 
-The `trigger` method is used to log an event with the framework. In combination with the `TrackingProvider` component, this enables an application to build the event fields and options throughout the DOM hierarchy and then trigger the event at the lowest level. Using this framework helps to ensure consistency in events as the lower level components can trigger the event generically while inheriting the fields and options defined higher in the DOM hierarchy through `TrackingProvider`.
+The `trigger` method is used to log an event with the framework. In combination with the `TrackingProvider` component, this enables an application to build the event analytics and options throughout the DOM hierarchy and then trigger the event at the lowest level. Using this framework helps to ensure consistency in events as the lower level components can trigger the event generically while inheriting the analytics and options defined higher in the DOM hierarchy through `TrackingProvider`.
 
 The `trigger` API has the following signature:
 
 ```javascript
-trigger(event, fields, options)
+trigger(event, analytics, options)
 ```
 
 Where:
 
 - **event** - The name of the event to trigger (String).
-- **fields** - The required and optional fields for the event (Object of string values).
+- **analytics** - The required and optional analytics for the event (Object of string values).
 - **options** - Options for the trigger API to use when triggering the event. (Object)
 
 ## Determine if provider exists

--- a/markdown/TrackingContext.md
+++ b/markdown/TrackingContext.md
@@ -4,7 +4,7 @@
 
 Structuring a component to use `TrackingContext` will provide access to the `trigger` method to trigger events. Use one of the two methods shown below to configure the context for a React component. Once configured as shown, the component can then access the `trigger` method via `this.context.trigger`.
 
-If the babel configuration for the application includes support for [public class analytics syntax](https://babeljs.io/docs/plugins/transform-class-properties/) and the application is using **react ^16.6.0**, use a *static* class field to initialize the `contextType`:
+If the babel configuration for the application includes support for [public class fields syntax](https://babeljs.io/docs/plugins/transform-class-properties/) and the application is using **react ^16.6.0**, use a *static* class field to initialize the `contextType`:
 
 ```jsx
 import React, {Component} from 'react';
@@ -20,7 +20,7 @@ class MyComponent extends Component {
 }
 ```
 
-Alternatively, if a component is not using public class analytics syntax, set the `contextType` directly on the class:
+Alternatively, if a component is not using public class fields syntax, set the `contextType` directly on the class:
 
 ```jsx
 import React, {Component} from 'react';
@@ -48,7 +48,7 @@ trigger(event, payload, options)
 Where:
 
 - **event** - The name of the event to trigger (String).
-- **payload** - The required and optional payload for the event (Object of string values).
+- **payload** - The required and optional payload for the event (Object of any values).
 - **options** - Options for the trigger API to use when triggering the event. (Object)
 
 ## Determine if provider exists

--- a/markdown/TrackingContext.md
+++ b/markdown/TrackingContext.md
@@ -1,4 +1,4 @@
-`TrackingContext` provides acccess to the current value of the context defined by a `TrackingProvider`. Use of `TrackingProvider` and `TrackingContext` enables an application to progressively build the analytics and options and then trigger events at the lowest level.
+`TrackingContext` provides acccess to the current value of the context defined by a `TrackingProvider`. Use of `TrackingProvider` and `TrackingContext` enables an application to progressively build the payload and options and then trigger events at the lowest level.
 
 ## Base Usage
 
@@ -37,18 +37,18 @@ MyComponent.contextType = TrackingContext;
 
 ## Trigger API
 
-The `trigger` method is used to log an event with the framework. In combination with the `TrackingProvider` component, this enables an application to build the event analytics and options throughout the DOM hierarchy and then trigger the event at the lowest level. Using this framework helps to ensure consistency in events as the lower level components can trigger the event generically while inheriting the analytics and options defined higher in the DOM hierarchy through `TrackingProvider`.
+The `trigger` method is used to log an event with the framework. In combination with the `TrackingProvider` component, this enables an application to build the event payload and options throughout the DOM hierarchy and then trigger the event at the lowest level. Using this framework helps to ensure consistency in events as the lower level components can trigger the event generically while inheriting the payload and options defined higher in the DOM hierarchy through `TrackingProvider`.
 
 The `trigger` API has the following signature:
 
 ```javascript
-trigger(event, analytics, options)
+trigger(event, payload, options)
 ```
 
 Where:
 
 - **event** - The name of the event to trigger (String).
-- **analytics** - The required and optional analytics for the event (Object of string values).
+- **payload** - The required and optional payload for the event (Object of string values).
 - **options** - Options for the trigger API to use when triggering the event. (Object)
 
 ## Determine if provider exists

--- a/markdown/TrackingProvider.md
+++ b/markdown/TrackingProvider.md
@@ -45,7 +45,7 @@ Where:
 
 ## TrackingProvider Nesting
 
-Multiple `TrackingProvider` components can be nested in order to iteratively enhance the configuration where the information is known. For example, consider a scenario where a `Calendar` component uses a `EventButton` component which triggers a `button.click` event. An application can build the set of payload needed for the `button.click` by nesting `TrackingProvider` wrappers in the areas of code that know the related information.
+Multiple `TrackingProvider` components can be nested in order to iteratively enhance the configuration where the information is known. For example, consider a scenario where a `Calendar` component uses a `EventButton` component which triggers a `button.click` event. An application can build the payload needed for the `button.click` by nesting `TrackingProvider` wrappers in the areas of code that know the related information.
 
 ### Example application wrapping a nested component
 
@@ -85,7 +85,7 @@ function CalendarButton(props) {
 }
 ```
 
-When `EventButton` triggers the `button.click` event, the trigger handler will be sent the combined set of payload (`{category: 'My App', location: 'top-right'}`) from the nested `TrackingProvider` instances.
+When `EventButton` triggers the `button.click` event, the trigger handler will be sent the combined payload (`{category: 'My App', location: 'top-right'}`) from the nested `TrackingProvider` instances.
 
 ## Event Specific Configuration
 

--- a/markdown/TrackingProvider.md
+++ b/markdown/TrackingProvider.md
@@ -1,23 +1,23 @@
-The `TrackingProvider` component allows an application to incrementally build the fields and options for events that will trigger from nested components. Using the `TrackingProvider` enables components at the lowest level to trigger events with the necessary set of fields and options. The consumer of the component is responsible for providing the implementation of the `trigger` API.
+The `TrackingProvider` component allows an application to incrementally build the analytics and options for events that will trigger from nested components. Using the `TrackingProvider` enables components at the lowest level to trigger events with the necessary set of analytics and options. The consumer of the component is responsible for providing the implementation of the `trigger` API.
 
 ## Base Usage
 
-Use the `TrackingProvider` component to wrap components that trigger events. Specify the desired fields and options to include when the event is triggered and an implementation of the `trigger` API.
+Use the `TrackingProvider` component to wrap components that trigger events. Specify the desired analytics and options to include when the event is triggered and an implementation of the `trigger` API.
 
 > **Note: It is strongly recommended that property values for the TrackingProvider be defined in state or constant variables instead of building the values dynamically on every render.**  If the values are constructed during the render, it will cause a FORCE RE-RENDER of ALL consumers of the context that are descendants of the provider even if the consumer's shouldComponentUpdate bails out. Following a pattern of defining property values as constants or via state will prevent unnecessary renders of children context consumers.
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const defaultFields = {location: 'top-right'};
+const defaultAnalytics = {location: 'top-right'};
 const defaultOptions = {asynchronous: true};
-const customTrigger = (event, fields, options) => {
+const customTrigger = (event, analytics, options) => {
     // Implement custom event tracking.
 }
 
 function App(props) {
     return (
         <TrackingProvider
-            fields={defaultFields}
+            analytics={defaultAnalytics}
             options={defaultOptions}
             trigger={customTrigger}
         >
@@ -34,32 +34,32 @@ function App(props) {
 The consumer is responsible for providing an implementation of the trigger method via the `trigger` property. The provided implementation is expected to have the following signature:
 
 ```javascript
-trigger(event, fields, options)
+trigger(event, analytics, options)
 ```
 
 Where:
 
 - **event** - The name of the event to trigger (String).
-- **fields** - The required and optional fields for the event (Object of string values).
+- **analytics** - The required and optional analytics for the event (Object of string values).
 - **options** - Options for the trigger API to use when triggering the event. (Object)
 
 ## TrackingProvider Nesting
 
-Multiple `TrackingProvider` components can be nested in order to iteratively enhance the configuration where the information is known. For example, consider a scenario where a `Calendar` component uses a `EventButton` component which triggers a `button.click` event. An application can build the set of fields needed for the `button.click` by nesting `TrackingProvider` wrappers in the areas of code that know the related information.
+Multiple `TrackingProvider` components can be nested in order to iteratively enhance the configuration where the information is known. For example, consider a scenario where a `Calendar` component uses a `EventButton` component which triggers a `button.click` event. An application can build the set of analytics needed for the `button.click` by nesting `TrackingProvider` wrappers in the areas of code that know the related information.
 
 ### Example application wrapping a nested component
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const appFields = {category: 'My App'};
-const customTrigger = (event, fields, options) => {
+const appAnalytics = {category: 'My App'};
+const customTrigger = (event, analytics, options) => {
     // Implement custom event tracking.
 };
 
 function App(props) {
     return (
         <TrackingProvider
-            fields={defaultFields}
+            analytics={defaultAnalytics}
             trigger={customTrigger}
         >
             // Events triggered by the Calendar component
@@ -70,35 +70,35 @@ function App(props) {
 }
 ```
 
-### Nested component providing additional fields
+### Nested component providing additional analytics
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const buttonFields = {location: 'top-right'};
+const buttonAnalytics = {location: 'top-right'};
 
 function CalendarButton(props) {
     return (
-        <TrackingProvider fields={buttonFields}>
+        <TrackingProvider analytics={buttonAnalytics}>
             <EventButton>{'Click Me'}</EventButton>
         </TrackingProvider>
     );
 }
 ```
 
-When `EventButton` triggers the `button.click` event, the trigger handler will be sent the combined set of fields (`{category: 'My App', location: 'top-right'}`) from the nested `TrackingProvider` instances.
+When `EventButton` triggers the `button.click` event, the trigger handler will be sent the combined set of analytics (`{category: 'My App', location: 'top-right'}`) from the nested `TrackingProvider` instances.
 
 ## Event Specific Configuration
 
-The `fields` and `options` properties serve as defaults for all events that are triggered by the nested components. If a wrapped component triggers multiple types of events, use the `eventFields` and `eventOptions` properties to configure the `TrackingProvider` with event specific configuration. Note that the event specific configuration will be merged with the default configuration if it is also specified.
+The `analytics` and `options` properties serve as defaults for all events that are triggered by the nested components. If a wrapped component triggers multiple types of events, use the `eventAnalytics` and `eventOptions` properties to configure the `TrackingProvider` with event specific configuration. Note that the event specific configuration will be merged with the default configuration if it is also specified.
 
 ### Specifying event specific details
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const defaultFields = {
+const defaultAnalytics = {
     eventcategory: 'My App'
 }
-const eventFields = {
+const eventAnalytics = {
     'generic.click': {
         eventaction: 'toggle'
     },
@@ -109,7 +109,7 @@ const eventFields = {
 
 function App(props) {
     return (
-        <TrackingProvider fields={defaultFields} eventFields={eventFields}>
+        <TrackingProvider analytics={defaultAnalytics} eventAnalytics={eventAnalytics}>
             <EventButton>{'Click Me'}</EventButton>
         </TrackingProvider>
     );

--- a/markdown/TrackingProvider.md
+++ b/markdown/TrackingProvider.md
@@ -1,23 +1,23 @@
-The `TrackingProvider` component allows an application to incrementally build the analytics and options for events that will trigger from nested components. Using the `TrackingProvider` enables components at the lowest level to trigger events with the necessary set of analytics and options. The consumer of the component is responsible for providing the implementation of the `trigger` API.
+The `TrackingProvider` component allows an application to incrementally build the payload and options for events that will trigger from nested components. Using the `TrackingProvider` enables components at the lowest level to trigger events with the necessary set of payload and options. The consumer of the component is responsible for providing the implementation of the `trigger` API.
 
 ## Base Usage
 
-Use the `TrackingProvider` component to wrap components that trigger events. Specify the desired analytics and options to include when the event is triggered and an implementation of the `trigger` API.
+Use the `TrackingProvider` component to wrap components that trigger events. Specify the desired payload and options to include when the event is triggered and an implementation of the `trigger` API.
 
 > **Note: It is strongly recommended that property values for the TrackingProvider be defined in state or constant variables instead of building the values dynamically on every render.**  If the values are constructed during the render, it will cause a FORCE RE-RENDER of ALL consumers of the context that are descendants of the provider even if the consumer's shouldComponentUpdate bails out. Following a pattern of defining property values as constants or via state will prevent unnecessary renders of children context consumers.
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const defaultAnalytics = {location: 'top-right'};
+const defaultPayload = {location: 'top-right'};
 const defaultOptions = {asynchronous: true};
-const customTrigger = (event, analytics, options) => {
+const customTrigger = (event, payload, options) => {
     // Implement custom event tracking.
 }
 
 function App(props) {
     return (
         <TrackingProvider
-            analytics={defaultAnalytics}
+            payload={defaultPayload}
             options={defaultOptions}
             trigger={customTrigger}
         >
@@ -34,32 +34,32 @@ function App(props) {
 The consumer is responsible for providing an implementation of the trigger method via the `trigger` property. The provided implementation is expected to have the following signature:
 
 ```javascript
-trigger(event, analytics, options)
+trigger(event, payload, options)
 ```
 
 Where:
 
 - **event** - The name of the event to trigger (String).
-- **analytics** - The required and optional analytics for the event (Object of string values).
+- **payload** - The required and optional payload for the event (Object of string values).
 - **options** - Options for the trigger API to use when triggering the event. (Object)
 
 ## TrackingProvider Nesting
 
-Multiple `TrackingProvider` components can be nested in order to iteratively enhance the configuration where the information is known. For example, consider a scenario where a `Calendar` component uses a `EventButton` component which triggers a `button.click` event. An application can build the set of analytics needed for the `button.click` by nesting `TrackingProvider` wrappers in the areas of code that know the related information.
+Multiple `TrackingProvider` components can be nested in order to iteratively enhance the configuration where the information is known. For example, consider a scenario where a `Calendar` component uses a `EventButton` component which triggers a `button.click` event. An application can build the set of payload needed for the `button.click` by nesting `TrackingProvider` wrappers in the areas of code that know the related information.
 
 ### Example application wrapping a nested component
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const appAnalytics = {category: 'My App'};
-const customTrigger = (event, analytics, options) => {
+const appPayload = {category: 'My App'};
+const customTrigger = (event, payload, options) => {
     // Implement custom event tracking.
 };
 
 function App(props) {
     return (
         <TrackingProvider
-            analytics={defaultAnalytics}
+            payload={defaultPayload}
             trigger={customTrigger}
         >
             // Events triggered by the Calendar component
@@ -70,35 +70,35 @@ function App(props) {
 }
 ```
 
-### Nested component providing additional analytics
+### Nested component providing additional payload
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const buttonAnalytics = {location: 'top-right'};
+const buttonPayload = {location: 'top-right'};
 
 function CalendarButton(props) {
     return (
-        <TrackingProvider analytics={buttonAnalytics}>
+        <TrackingProvider payload={buttonPayload}>
             <EventButton>{'Click Me'}</EventButton>
         </TrackingProvider>
     );
 }
 ```
 
-When `EventButton` triggers the `button.click` event, the trigger handler will be sent the combined set of analytics (`{category: 'My App', location: 'top-right'}`) from the nested `TrackingProvider` instances.
+When `EventButton` triggers the `button.click` event, the trigger handler will be sent the combined set of payload (`{category: 'My App', location: 'top-right'}`) from the nested `TrackingProvider` instances.
 
 ## Event Specific Configuration
 
-The `analytics` and `options` properties serve as defaults for all events that are triggered by the nested components. If a wrapped component triggers multiple types of events, use the `eventAnalytics` and `eventOptions` properties to configure the `TrackingProvider` with event specific configuration. Note that the event specific configuration will be merged with the default configuration if it is also specified.
+The `payload` and `options` properties serve as defaults for all events that are triggered by the nested components. If a wrapped component triggers multiple types of events, use the `eventPayload` and `eventOptions` properties to configure the `TrackingProvider` with event specific configuration. Note that the event specific configuration will be merged with the default configuration if it is also specified.
 
 ### Specifying event specific details
 
 ```jsx
 import {TrackingProvider} from '@vrbo/react-event-tracking';
-const defaultAnalytics = {
+const defaultPayload = {
     eventcategory: 'My App'
 }
-const eventAnalytics = {
+const eventPayload = {
     'generic.click': {
         eventaction: 'toggle'
     },
@@ -109,7 +109,7 @@ const eventAnalytics = {
 
 function App(props) {
     return (
-        <TrackingProvider analytics={defaultAnalytics} eventAnalytics={eventAnalytics}>
+        <TrackingProvider payload={defaultPayload} eventPayload={eventPayload}>
             <EventButton>{'Click Me'}</EventButton>
         </TrackingProvider>
     );

--- a/markdown/TrackingTrigger.md
+++ b/markdown/TrackingTrigger.md
@@ -2,11 +2,11 @@ The `TrackingTrigger` component allows an application to declaratively trigger a
 
 ## Base Usage
 
-Use the `TrackingTrigger` component within a `TrackingProvider` component hierarchy. Specify the desired event name, fields and options to include when the event is triggered. The event will be triggered with a merge of the specified fields and options and the current context when the component's `componentDidMount` is invoked.
+Use the `TrackingTrigger` component within a `TrackingProvider` component hierarchy. Specify the desired event name, analytics and options to include when the event is triggered. The event will be triggered with a merge of the specified analytics and options and the current context when the component's `componentDidMount` is invoked.
 
 ```jsx
 import {TrackingTrigger} from '@vrbo/react-event-tracking';
-const eventFields = {
+const eventAnalytics = {
     location: 'searchbar',
     name: 'SomeComponent'
 };
@@ -17,7 +17,7 @@ function SomeComponent(props) {
         ...
         <TrackingTrigger
             event={'visible'}
-            fields={eventFields}
+            analytics={eventAnalytics}
             options={eventOptions}
         />
     );

--- a/markdown/TrackingTrigger.md
+++ b/markdown/TrackingTrigger.md
@@ -2,11 +2,11 @@ The `TrackingTrigger` component allows an application to declaratively trigger a
 
 ## Base Usage
 
-Use the `TrackingTrigger` component within a `TrackingProvider` component hierarchy. Specify the desired event name, analytics and options to include when the event is triggered. The event will be triggered with a merge of the specified analytics and options and the current context when the component's `componentDidMount` is invoked.
+Use the `TrackingTrigger` component within a `TrackingProvider` component hierarchy. Specify the desired event name, payload and options to include when the event is triggered. The event will be triggered with a merge of the specified payload and options and the current context when the component's `componentDidMount` is invoked.
 
 ```jsx
 import {TrackingTrigger} from '@vrbo/react-event-tracking';
-const eventAnalytics = {
+const eventPayload = {
     location: 'searchbar',
     name: 'SomeComponent'
 };
@@ -17,7 +17,7 @@ function SomeComponent(props) {
         ...
         <TrackingTrigger
             event={'visible'}
-            analytics={eventAnalytics}
+            payload={eventPayload}
             options={eventOptions}
         />
     );

--- a/pages/harness/components/EventButton.js
+++ b/pages/harness/components/EventButton.js
@@ -23,7 +23,7 @@ class EventButton extends PureComponent {
     static propTypes = {
         /** Event name. */
         event: PropTypes.string,
-        /** Object of string values that represents the default payload to apply to all events within this context. */
+        /** Object of key/value pairs that represents the default payload to apply to all events within this context. */
         payload: PropTypes.objectOf(PropTypes.any),
         /** Button label. */
         label: PropTypes.string,

--- a/pages/harness/components/EventButton.js
+++ b/pages/harness/components/EventButton.js
@@ -23,8 +23,8 @@ class EventButton extends PureComponent {
     static propTypes = {
         /** Event name. */
         event: PropTypes.string,
-        /** Object of string values that represents the default fields to apply to all events within this context. */
-        fields: PropTypes.objectOf(PropTypes.string),
+        /** Object of string values that represents the default analytics to apply to all events within this context. */
+        analytics: PropTypes.objectOf(PropTypes.any),
         /** Button label. */
         label: PropTypes.string,
         /** The trigger options. */
@@ -33,7 +33,7 @@ class EventButton extends PureComponent {
 
     static defaultProps = {
         event: 'generic.click',
-        fields: {},
+        analytics: {},
         label: 'Click Me',
         options: {}
     };
@@ -43,9 +43,9 @@ class EventButton extends PureComponent {
     }
 
     handleClick = () => {
-        const {event, fields, options} = this.props;
+        const {event, analytics, options} = this.props;
 
-        this.context.trigger(event, fields, options);
+        this.context.trigger(event, analytics, options);
     }
 
     render() {

--- a/pages/harness/components/EventButton.js
+++ b/pages/harness/components/EventButton.js
@@ -23,8 +23,8 @@ class EventButton extends PureComponent {
     static propTypes = {
         /** Event name. */
         event: PropTypes.string,
-        /** Object of string values that represents the default analytics to apply to all events within this context. */
-        analytics: PropTypes.objectOf(PropTypes.any),
+        /** Object of string values that represents the default payload to apply to all events within this context. */
+        payload: PropTypes.objectOf(PropTypes.any),
         /** Button label. */
         label: PropTypes.string,
         /** The trigger options. */
@@ -33,7 +33,7 @@ class EventButton extends PureComponent {
 
     static defaultProps = {
         event: 'generic.click',
-        analytics: {},
+        payload: {},
         label: 'Click Me',
         options: {}
     };
@@ -43,9 +43,9 @@ class EventButton extends PureComponent {
     }
 
     handleClick = () => {
-        const {event, analytics, options} = this.props;
+        const {event, payload, options} = this.props;
 
-        this.context.trigger(event, analytics, options);
+        this.context.trigger(event, payload, options);
     }
 
     render() {

--- a/pages/harness/components/EventButtonMultipleContextType.js
+++ b/pages/harness/components/EventButtonMultipleContextType.js
@@ -24,8 +24,8 @@ class EventButtonMultiple extends PureComponent {
     static propTypes = {
         /** Event name. */
         event: PropTypes.string,
-        /** Object of string values that represents the default fields to apply to all events within this context. */
-        fields: PropTypes.objectOf(PropTypes.string),
+        /** Object of string values that represents the default analytics to apply to all events within this context. */
+        analytics: PropTypes.objectOf(PropTypes.any),
         /** Button label. */
         label: PropTypes.string,
         /** The trigger options. */
@@ -35,7 +35,7 @@ class EventButtonMultiple extends PureComponent {
     static defaultProps = {
         event: 'generic.click',
         expected: {},
-        fields: {},
+        analytics: {},
         label: 'Click Me',
         options: {}
     };
@@ -53,9 +53,9 @@ class EventButtonMultiple extends PureComponent {
     }
 
     handleClick = () => {
-        const {event, fields, options} = this.props;
+        const {event, analytics, options} = this.props;
 
-        this.context.trigger(event, fields, options);
+        this.context.trigger(event, analytics, options);
         this.check(this.secondValue);
     }
 

--- a/pages/harness/components/EventButtonMultipleContextType.js
+++ b/pages/harness/components/EventButtonMultipleContextType.js
@@ -24,7 +24,7 @@ class EventButtonMultiple extends PureComponent {
     static propTypes = {
         /** Event name. */
         event: PropTypes.string,
-        /** Object of string values that represents the default payload to apply to all events within this context. */
+        /** Object of key/value pairs that represents the default payload to apply to all events within this context. */
         payload: PropTypes.objectOf(PropTypes.any),
         /** Button label. */
         label: PropTypes.string,

--- a/pages/harness/components/EventButtonMultipleContextType.js
+++ b/pages/harness/components/EventButtonMultipleContextType.js
@@ -24,8 +24,8 @@ class EventButtonMultiple extends PureComponent {
     static propTypes = {
         /** Event name. */
         event: PropTypes.string,
-        /** Object of string values that represents the default analytics to apply to all events within this context. */
-        analytics: PropTypes.objectOf(PropTypes.any),
+        /** Object of string values that represents the default payload to apply to all events within this context. */
+        payload: PropTypes.objectOf(PropTypes.any),
         /** Button label. */
         label: PropTypes.string,
         /** The trigger options. */
@@ -35,7 +35,7 @@ class EventButtonMultiple extends PureComponent {
     static defaultProps = {
         event: 'generic.click',
         expected: {},
-        analytics: {},
+        payload: {},
         label: 'Click Me',
         options: {}
     };
@@ -53,9 +53,9 @@ class EventButtonMultiple extends PureComponent {
     }
 
     handleClick = () => {
-        const {event, analytics, options} = this.props;
+        const {event, payload, options} = this.props;
 
-        this.context.trigger(event, analytics, options);
+        this.context.trigger(event, payload, options);
         this.check(this.secondValue);
     }
 

--- a/pages/harness/components/SecondContext.js
+++ b/pages/harness/components/SecondContext.js
@@ -16,7 +16,7 @@
 import React from 'react';
 
 const context = {
-    myAnalytics: {},
+    myPayload: {},
     otherStuff: {}
 };
 

--- a/pages/harness/components/SecondContext.js
+++ b/pages/harness/components/SecondContext.js
@@ -16,7 +16,7 @@
 import React from 'react';
 
 const context = {
-    myFields: {},
+    myAnalytics: {},
     otherStuff: {}
 };
 

--- a/pages/harness/components/SecondContextChecker.js
+++ b/pages/harness/components/SecondContextChecker.js
@@ -20,7 +20,7 @@ import './SecondContextChecker.less';
 
 class SecondContextChecker extends PureComponent {
     static propTypes = {
-        /** Object of string values that represents the default fields to apply to all events within this context. */
+        /** Object of string values that represents the default analytics to apply to all events within this context. */
         expected: PropTypes.object
     };
 

--- a/pages/harness/components/SecondContextChecker.js
+++ b/pages/harness/components/SecondContextChecker.js
@@ -20,7 +20,7 @@ import './SecondContextChecker.less';
 
 class SecondContextChecker extends PureComponent {
     static propTypes = {
-        /** Object of string values that represents the default analytics to apply to all events within this context. */
+        /** Object of string values that represents the default payload to apply to all events within this context. */
         expected: PropTypes.object
     };
 

--- a/pages/harness/components/SecondContextChecker.js
+++ b/pages/harness/components/SecondContextChecker.js
@@ -20,7 +20,7 @@ import './SecondContextChecker.less';
 
 class SecondContextChecker extends PureComponent {
     static propTypes = {
-        /** Object of string values that represents the default payload to apply to all events within this context. */
+        /** Object of key/value pairs that represents the default payload to apply to all events within this context. */
         expected: PropTypes.object
     };
 

--- a/pages/harness/components/TrackingChecker.js
+++ b/pages/harness/components/TrackingChecker.js
@@ -20,13 +20,13 @@ import './TrackingChecker.less';
 
 class TrackingChecker extends PureComponent {
     static propTypes = {
-        /** An object of event specific payload where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `payload` property. */
+        /** An object of event specific payloads where the event name is the key and the value is an object of key/value pairs for the event. Event specific values will be merged with defaults from the `payload` property. */
         eventPayload: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
         /** An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. */
         eventOptions: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
         /** The expected data configuration. */
         expected: PropTypes.object,
-        /** Object of string values that represents the default payload to apply to all events within this context. */
+        /** Object of key/value pairs that represents the default payload to apply to all events within this context. */
         payload: PropTypes.objectOf(PropTypes.any),
         /** The trigger options. */
         options: PropTypes.objectOf(PropTypes.any),

--- a/pages/harness/components/TrackingChecker.js
+++ b/pages/harness/components/TrackingChecker.js
@@ -20,16 +20,16 @@ import './TrackingChecker.less';
 
 class TrackingChecker extends PureComponent {
     static propTypes = {
-        /** An object of event specific fields where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `fields` property. */
-        eventFields: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
+        /** An object of event specific analytics where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `analytics` property. */
+        eventAnalytics: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
         /** An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. */
-        eventOptions: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
+        eventOptions: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
         /** The expected data configuration. */
         expected: PropTypes.object,
-        /** Object of string values that represents the default fields to apply to all events within this context. */
-        fields: PropTypes.objectOf(PropTypes.string),
+        /** Object of string values that represents the default analytics to apply to all events within this context. */
+        analytics: PropTypes.objectOf(PropTypes.any),
         /** The trigger options. */
-        options: PropTypes.objectOf(PropTypes.string),
+        options: PropTypes.objectOf(PropTypes.any),
         /** When true, overwrites the current context with specified properties. Default is to merge instead of overwrite. */
         overwrite: PropTypes.bool,
     };
@@ -44,11 +44,11 @@ class TrackingChecker extends PureComponent {
         isValid: null
     };
 
-    trigger = (event, fields, options) => {
+    trigger = (event, analytics, options) => {
         const {expected} = this.props;
 
         if (expected) {
-            const actual = {event, fields, options};
+            const actual = {event, analytics, options};
             const expectedStr = JSON.stringify(expected);
             const actualStr = JSON.stringify(actual);
 
@@ -65,7 +65,7 @@ class TrackingChecker extends PureComponent {
             }
         }
 
-        console.log(`Triggered ${event} with fields: `, fields, ' and options: ', options);
+        console.log(`Triggered ${event} with analytics: `, analytics, ' and options: ', options);
     }
 
     render() {

--- a/pages/harness/components/TrackingChecker.js
+++ b/pages/harness/components/TrackingChecker.js
@@ -20,14 +20,14 @@ import './TrackingChecker.less';
 
 class TrackingChecker extends PureComponent {
     static propTypes = {
-        /** An object of event specific analytics where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `analytics` property. */
-        eventAnalytics: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
+        /** An object of event specific payload where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `payload` property. */
+        eventPayload: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
         /** An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. */
         eventOptions: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
         /** The expected data configuration. */
         expected: PropTypes.object,
-        /** Object of string values that represents the default analytics to apply to all events within this context. */
-        analytics: PropTypes.objectOf(PropTypes.any),
+        /** Object of string values that represents the default payload to apply to all events within this context. */
+        payload: PropTypes.objectOf(PropTypes.any),
         /** The trigger options. */
         options: PropTypes.objectOf(PropTypes.any),
         /** When true, overwrites the current context with specified properties. Default is to merge instead of overwrite. */
@@ -44,11 +44,11 @@ class TrackingChecker extends PureComponent {
         isValid: null
     };
 
-    trigger = (event, analytics, options) => {
+    trigger = (event, payload, options) => {
         const {expected} = this.props;
 
         if (expected) {
-            const actual = {event, analytics, options};
+            const actual = {event, payload, options};
             const expectedStr = JSON.stringify(expected);
             const actualStr = JSON.stringify(actual);
 
@@ -65,7 +65,7 @@ class TrackingChecker extends PureComponent {
             }
         }
 
-        console.log(`Triggered ${event} with analytics: `, analytics, ' and options: ', options);
+        console.log(`Triggered ${event} with payload: `, payload, ' and options: ', options);
     }
 
     render() {

--- a/pages/harness/harness.js
+++ b/pages/harness/harness.js
@@ -23,7 +23,7 @@ import SecondContextChecker from './components/SecondContextChecker';
 import './harness.less';
 
 const SECONDCONTEXT = {
-    myAnalytics: 'true',
+    myPayload: 'true',
     otherStuff: 'false'
 };
 
@@ -63,22 +63,22 @@ function harness() {
             </dl>
             <h1>{'TrackingProvider and TrackingContext contextType'}</h1>
             <p>{'All these events have been setup to trigger on mount but can be manually triggered by clicking the related button.'}</p>
-            <h2>{'Provider with no analytics or options.'}</h2>
+            <h2>{'Provider with no payload or options.'}</h2>
             <TrackingChecker expected={{
                 event: 'generic.click',
-                analytics: {},
+                payload: {},
                 options: {}}}
             >
                 <EventButton label={'Generate generic.click'} />
             </TrackingChecker>
 
-            <h2>{'Provider with analytics and no options.'}</h2>
-            <TrackingChecker analytics={{
+            <h2>{'Provider with payload and no options.'}</h2>
+            <TrackingChecker payload={{
                 'actionlocation': 'left',
                 'eventcategory': 'harness'
             }} expected={{
                 event: 'generic.click',
-                analytics: {
+                payload: {
                     actionlocation: 'left',
                     eventcategory: 'harness'
                 },
@@ -87,13 +87,13 @@ function harness() {
                 <EventButton label={'Generate generic.click'} />
             </TrackingChecker>
 
-            <h2>{'Nested Provider with analytics and no options.'}</h2>
-            <TrackingProvider analytics={{'actionlocation': 'top'}}>
+            <h2>{'Nested Provider with payload and no options.'}</h2>
+            <TrackingProvider payload={{'actionlocation': 'top'}}>
                 <TrackingChecker
-                    analytics={{'eventcategory': 'harness'}}
+                    payload={{'eventcategory': 'harness'}}
                     expected={{
                         event: 'generic.click',
-                        analytics: {
+                        payload: {
                             actionlocation: 'top',
                             eventcategory: 'harness'
                         },
@@ -104,17 +104,17 @@ function harness() {
             </TrackingProvider>
 
             <h2>{'Nested Provider with field overrides and no options.'}</h2>
-            <TrackingProvider analytics={{
+            <TrackingProvider payload={{
                 'actionlocation': 'left',
                 'eventcategory': 'junk'}}
             >
                 <TrackingChecker
-                    analytics={{
+                    payload={{
                         'actionlocation': 'top',
                         'eventcategory': 'harness'}}
                     expected={{
                         event: 'generic.click',
-                        analytics: {
+                        payload: {
                             actionlocation: 'top',
                             eventcategory: 'harness'
                         },
@@ -124,12 +124,12 @@ function harness() {
                 </TrackingChecker>
             </TrackingProvider>
 
-            <h2>{'Provider with analytics and eventAnalytics with no options.'}</h2>
+            <h2>{'Provider with payload and eventPayload with no options.'}</h2>
             <TrackingChecker
-                analytics={{
+                payload={{
                     'actionlocation': 'left',
                     'eventcategory': 'harness'
-                }} eventAnalytics={{
+                }} eventPayload={{
                     'generic.click': {
                         'eventlabel': 'custom'
                     },
@@ -139,7 +139,7 @@ function harness() {
                 }}
                 expected={{
                     event: 'generic.click',
-                    analytics: {
+                    payload: {
                         actionlocation: 'left',
                         eventcategory: 'harness',
                         eventlabel: 'custom'
@@ -149,13 +149,13 @@ function harness() {
                 <EventButton label={'Generate generic.click'}/>
             </TrackingChecker>
 
-            <h2>{'Nested Provider with analytics and eventAnalytics with no options.'}</h2>
+            <h2>{'Nested Provider with payload and eventPayload with no options.'}</h2>
             <TrackingProvider
-                analytics={{
+                payload={{
                     'actionlocation': 'left',
                     'eventcategory': 'harness',
                     'eventvalue': 'a value'
-                }} eventAnalytics={{
+                }} eventPayload={{
                     'generic.click': {
                         'eventlabel': 'skip',
                         'highfrequency': 'false'
@@ -166,18 +166,18 @@ function harness() {
                 }}
             >
                 <TrackingChecker
-                    analytics={{
+                    payload={{
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     }}
-                    eventAnalytics={{
+                    eventPayload={{
                         'generic.click': {
                             'eventlabel': 'custom'
                         }
                     }}
                     expected={{
                         event: 'generic.click',
-                        analytics: {
+                        payload: {
                             actionlocation: 'top',
                             eventcategory: 'test',
                             eventvalue: 'a value',
@@ -190,12 +190,12 @@ function harness() {
                 </TrackingChecker>
             </TrackingProvider>
 
-            <h2>{'Nested Provider with analytics, eventAnalytics, options and eventOptions.'}</h2>
-            <TrackingProvider analytics={{
+            <h2>{'Nested Provider with payload, eventPayload, options and eventOptions.'}</h2>
+            <TrackingProvider payload={{
                 'actionlocation': 'left',
                 'eventcategory': 'harness',
                 'eventvalue': 'a value'
-            }} eventAnalytics={{
+            }} eventPayload={{
                 'generic.click': {
                     'eventlabel': 'skip',
                     'highfrequency': 'false'
@@ -212,11 +212,11 @@ function harness() {
             }}
             >
                 <TrackingChecker
-                    analytics={{
+                    payload={{
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     }}
-                    eventAnalytics={{
+                    eventPayload={{
                         'generic.click': {
                             'eventlabel': 'custom'
                         }
@@ -231,7 +231,7 @@ function harness() {
                     }}
                     expected={{
                         event: 'generic.click',
-                        analytics: {
+                        payload: {
                             actionlocation: 'top',
                             eventcategory: 'test',
                             eventvalue: 'a value',
@@ -249,13 +249,13 @@ function harness() {
 
             <h2>{'Provider with component consuming multiple contexts with one of them being contextType.'}</h2>
             <TrackingChecker
-                analytics={{
+                payload={{
                     'actionlocation': 'left',
                     'eventcategory': 'harness'
                 }}
                 expected={{
                     event: 'generic.click',
-                    analytics: {
+                    payload: {
                         actionlocation: 'left',
                         eventcategory: 'harness'
                     },
@@ -271,22 +271,22 @@ function harness() {
 
             <h1>{'TrackingTrigger'}</h1>
 
-            <h2>{'Trigger with no analytics or options.'}</h2>
+            <h2>{'Trigger with no payload or options.'}</h2>
             <TrackingChecker
                 expected={{
                     event: 'generic.click',
-                    analytics: {},
+                    payload: {},
                     options: {}}}
             >
                 <TrackingTrigger event={'generic.click'}/>
                 <span>{'generic.click'}</span>
             </TrackingChecker>
 
-            <h2>{'Trigger with analytics and options for TrackingTrigger.'}</h2>
+            <h2>{'Trigger with payload and options for TrackingTrigger.'}</h2>
             <TrackingChecker
                 expected={{
                     event: 'generic.click',
-                    analytics: {
+                    payload: {
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     },
@@ -295,7 +295,7 @@ function harness() {
                     }}}
             >
                 <TrackingTrigger event={'generic.click'}
-                    analytics={{
+                    payload={{
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     }}
@@ -306,14 +306,14 @@ function harness() {
                 <span>{'generic.click'}</span>
             </TrackingChecker>
 
-            <h2>{'Trigger with analytics and options for TrackingTrigger and TrackingProvider with analytics and options.'}</h2>
+            <h2>{'Trigger with payload and options for TrackingTrigger and TrackingProvider with payload and options.'}</h2>
             <TrackingChecker
-                analytics={{
+                payload={{
                     'actionlocation': 'left',
                     'eventcategory': 'harness',
                     'eventvalue': 'a value'
                 }}
-                eventAnalytics={{
+                eventPayload={{
                     'generic.click': {
                         'eventlabel': 'skip',
                         'highfrequency': 'false'
@@ -333,7 +333,7 @@ function harness() {
                 }}
                 expected={{
                     event: 'generic.click',
-                    analytics: {
+                    payload: {
                         'actionlocation': 'top',
                         'eventcategory': 'test',
                         'eventvalue': 'a value',
@@ -346,7 +346,7 @@ function harness() {
                     }}}
             >
                 <TrackingTrigger event={'generic.click'}
-                    analytics={{
+                    payload={{
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     }}
@@ -359,7 +359,7 @@ function harness() {
 
             <h2>{'Trigger with no provider should not cause hard failure.'}</h2>
             <TrackingTrigger event={'generic.click'}
-                analytics={{
+                payload={{
                     'actionlocation': 'top',
                     'eventcategory': 'test'
                 }}

--- a/pages/harness/harness.js
+++ b/pages/harness/harness.js
@@ -23,7 +23,7 @@ import SecondContextChecker from './components/SecondContextChecker';
 import './harness.less';
 
 const SECONDCONTEXT = {
-    myFields: 'true',
+    myAnalytics: 'true',
     otherStuff: 'false'
 };
 
@@ -63,22 +63,22 @@ function harness() {
             </dl>
             <h1>{'TrackingProvider and TrackingContext contextType'}</h1>
             <p>{'All these events have been setup to trigger on mount but can be manually triggered by clicking the related button.'}</p>
-            <h2>{'Provider with no fields or options.'}</h2>
+            <h2>{'Provider with no analytics or options.'}</h2>
             <TrackingChecker expected={{
                 event: 'generic.click',
-                fields: {},
+                analytics: {},
                 options: {}}}
             >
                 <EventButton label={'Generate generic.click'} />
             </TrackingChecker>
 
-            <h2>{'Provider with fields and no options.'}</h2>
-            <TrackingChecker fields={{
+            <h2>{'Provider with analytics and no options.'}</h2>
+            <TrackingChecker analytics={{
                 'actionlocation': 'left',
                 'eventcategory': 'harness'
             }} expected={{
                 event: 'generic.click',
-                fields: {
+                analytics: {
                     actionlocation: 'left',
                     eventcategory: 'harness'
                 },
@@ -87,13 +87,13 @@ function harness() {
                 <EventButton label={'Generate generic.click'} />
             </TrackingChecker>
 
-            <h2>{'Nested Provider with fields and no options.'}</h2>
-            <TrackingProvider fields={{'actionlocation': 'top'}}>
+            <h2>{'Nested Provider with analytics and no options.'}</h2>
+            <TrackingProvider analytics={{'actionlocation': 'top'}}>
                 <TrackingChecker
-                    fields={{'eventcategory': 'harness'}}
+                    analytics={{'eventcategory': 'harness'}}
                     expected={{
                         event: 'generic.click',
-                        fields: {
+                        analytics: {
                             actionlocation: 'top',
                             eventcategory: 'harness'
                         },
@@ -104,17 +104,17 @@ function harness() {
             </TrackingProvider>
 
             <h2>{'Nested Provider with field overrides and no options.'}</h2>
-            <TrackingProvider fields={{
+            <TrackingProvider analytics={{
                 'actionlocation': 'left',
                 'eventcategory': 'junk'}}
             >
                 <TrackingChecker
-                    fields={{
+                    analytics={{
                         'actionlocation': 'top',
                         'eventcategory': 'harness'}}
                     expected={{
                         event: 'generic.click',
-                        fields: {
+                        analytics: {
                             actionlocation: 'top',
                             eventcategory: 'harness'
                         },
@@ -124,12 +124,12 @@ function harness() {
                 </TrackingChecker>
             </TrackingProvider>
 
-            <h2>{'Provider with fields and eventFields with no options.'}</h2>
+            <h2>{'Provider with analytics and eventAnalytics with no options.'}</h2>
             <TrackingChecker
-                fields={{
+                analytics={{
                     'actionlocation': 'left',
                     'eventcategory': 'harness'
-                }} eventFields={{
+                }} eventAnalytics={{
                     'generic.click': {
                         'eventlabel': 'custom'
                     },
@@ -139,7 +139,7 @@ function harness() {
                 }}
                 expected={{
                     event: 'generic.click',
-                    fields: {
+                    analytics: {
                         actionlocation: 'left',
                         eventcategory: 'harness',
                         eventlabel: 'custom'
@@ -149,13 +149,13 @@ function harness() {
                 <EventButton label={'Generate generic.click'}/>
             </TrackingChecker>
 
-            <h2>{'Nested Provider with fields and eventFields with no options.'}</h2>
+            <h2>{'Nested Provider with analytics and eventAnalytics with no options.'}</h2>
             <TrackingProvider
-                fields={{
+                analytics={{
                     'actionlocation': 'left',
                     'eventcategory': 'harness',
                     'eventvalue': 'a value'
-                }} eventFields={{
+                }} eventAnalytics={{
                     'generic.click': {
                         'eventlabel': 'skip',
                         'highfrequency': 'false'
@@ -166,18 +166,18 @@ function harness() {
                 }}
             >
                 <TrackingChecker
-                    fields={{
+                    analytics={{
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     }}
-                    eventFields={{
+                    eventAnalytics={{
                         'generic.click': {
                             'eventlabel': 'custom'
                         }
                     }}
                     expected={{
                         event: 'generic.click',
-                        fields: {
+                        analytics: {
                             actionlocation: 'top',
                             eventcategory: 'test',
                             eventvalue: 'a value',
@@ -190,12 +190,12 @@ function harness() {
                 </TrackingChecker>
             </TrackingProvider>
 
-            <h2>{'Nested Provider with fields, eventFields, options and eventOptions.'}</h2>
-            <TrackingProvider fields={{
+            <h2>{'Nested Provider with analytics, eventAnalytics, options and eventOptions.'}</h2>
+            <TrackingProvider analytics={{
                 'actionlocation': 'left',
                 'eventcategory': 'harness',
                 'eventvalue': 'a value'
-            }} eventFields={{
+            }} eventAnalytics={{
                 'generic.click': {
                     'eventlabel': 'skip',
                     'highfrequency': 'false'
@@ -212,11 +212,11 @@ function harness() {
             }}
             >
                 <TrackingChecker
-                    fields={{
+                    analytics={{
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     }}
-                    eventFields={{
+                    eventAnalytics={{
                         'generic.click': {
                             'eventlabel': 'custom'
                         }
@@ -231,7 +231,7 @@ function harness() {
                     }}
                     expected={{
                         event: 'generic.click',
-                        fields: {
+                        analytics: {
                             actionlocation: 'top',
                             eventcategory: 'test',
                             eventvalue: 'a value',
@@ -249,13 +249,13 @@ function harness() {
 
             <h2>{'Provider with component consuming multiple contexts with one of them being contextType.'}</h2>
             <TrackingChecker
-                fields={{
+                analytics={{
                     'actionlocation': 'left',
                     'eventcategory': 'harness'
                 }}
                 expected={{
                     event: 'generic.click',
-                    fields: {
+                    analytics: {
                         actionlocation: 'left',
                         eventcategory: 'harness'
                     },
@@ -271,22 +271,22 @@ function harness() {
 
             <h1>{'TrackingTrigger'}</h1>
 
-            <h2>{'Trigger with no fields or options.'}</h2>
+            <h2>{'Trigger with no analytics or options.'}</h2>
             <TrackingChecker
                 expected={{
                     event: 'generic.click',
-                    fields: {},
+                    analytics: {},
                     options: {}}}
             >
                 <TrackingTrigger event={'generic.click'}/>
                 <span>{'generic.click'}</span>
             </TrackingChecker>
 
-            <h2>{'Trigger with fields and options for TrackingTrigger.'}</h2>
+            <h2>{'Trigger with analytics and options for TrackingTrigger.'}</h2>
             <TrackingChecker
                 expected={{
                     event: 'generic.click',
-                    fields: {
+                    analytics: {
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     },
@@ -295,7 +295,7 @@ function harness() {
                     }}}
             >
                 <TrackingTrigger event={'generic.click'}
-                    fields={{
+                    analytics={{
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     }}
@@ -306,14 +306,14 @@ function harness() {
                 <span>{'generic.click'}</span>
             </TrackingChecker>
 
-            <h2>{'Trigger with fields and options for TrackingTrigger and TrackingProvider with fields and options.'}</h2>
+            <h2>{'Trigger with analytics and options for TrackingTrigger and TrackingProvider with analytics and options.'}</h2>
             <TrackingChecker
-                fields={{
+                analytics={{
                     'actionlocation': 'left',
                     'eventcategory': 'harness',
                     'eventvalue': 'a value'
                 }}
-                eventFields={{
+                eventAnalytics={{
                     'generic.click': {
                         'eventlabel': 'skip',
                         'highfrequency': 'false'
@@ -333,7 +333,7 @@ function harness() {
                 }}
                 expected={{
                     event: 'generic.click',
-                    fields: {
+                    analytics: {
                         'actionlocation': 'top',
                         'eventcategory': 'test',
                         'eventvalue': 'a value',
@@ -346,7 +346,7 @@ function harness() {
                     }}}
             >
                 <TrackingTrigger event={'generic.click'}
-                    fields={{
+                    analytics={{
                         'actionlocation': 'top',
                         'eventcategory': 'test'
                     }}
@@ -359,7 +359,7 @@ function harness() {
 
             <h2>{'Trigger with no provider should not cause hard failure.'}</h2>
             <TrackingTrigger event={'generic.click'}
-                fields={{
+                analytics={{
                     'actionlocation': 'top',
                     'eventcategory': 'test'
                 }}

--- a/src/components/TrackingProvider/TrackingProvider.js
+++ b/src/components/TrackingProvider/TrackingProvider.js
@@ -24,13 +24,13 @@ import TrackingContext from '../../context/TrackingContext';
  */
 class TrackingProvider extends PureComponent {
     static propTypes = {
-        /** (Deprecated) An object of event specific payload where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `payload` property. */
+        /** (Deprecated) An object of event specific fields where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `fields` property. The `eventPayload` property takes precedence over this property if both are specified. */
         eventFields: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
-        /** An object of event specific payload where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `payload` property. */
+        /** An object of event specific payloads where the event name is the key and the value is an object of key/value pairs for the event. Event specific values will be merged with defaults from the `payload` property. */
         eventPayload: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
         /** An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. */
         eventOptions: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
-        /** (Deprecated) Object of string values that represents the default payload to apply to all events within this context. */
+        /** (Deprecated) Object of string values that represents the default payload to apply to all events within this context. The `payload` property takes precedence over this property if both specified. */
         fields: PropTypes.objectOf(PropTypes.string),
         /** Object of values that represents the default payload to apply to all events within this context. */
         payload: PropTypes.objectOf(PropTypes.any),

--- a/src/components/TrackingProvider/TrackingProvider.js
+++ b/src/components/TrackingProvider/TrackingProvider.js
@@ -79,10 +79,6 @@ class TrackingProvider extends PureComponent {
         eventPayload = eventPayload || eventFields;
         payload = payload || fields;
 
-        // Necessary for overwrite fall back
-        data.eventPayload = data.eventPayload || data.eventFields;
-        data.payload = data.payload || data.fields;
-
         if (overwrite) {
             newData.eventPayload = eventPayload || data.eventPayload;
             newData.eventOptions = eventOptions || data.eventOptions;

--- a/src/components/TrackingProvider/TrackingProvider.js
+++ b/src/components/TrackingProvider/TrackingProvider.js
@@ -75,8 +75,13 @@ class TrackingProvider extends PureComponent {
         let {eventPayload, payload} = this.props;
         const newData = {};
 
+        // Prefer new data payload name, but fall back for backwards compatibility
         eventPayload = eventPayload || eventFields;
         payload = payload || fields;
+
+        // Necessary for overwrite fall back
+        data.eventPayload = data.eventPayload || data.eventFields;
+        data.payload = data.payload || data.fields;
 
         if (overwrite) {
             newData.eventPayload = eventPayload || data.eventPayload;

--- a/src/components/TrackingProvider/TrackingProvider.js
+++ b/src/components/TrackingProvider/TrackingProvider.js
@@ -20,18 +20,18 @@ import TrackingContext from '../../context/TrackingContext';
 /**
  * A React context provider that allows nesting to generate new context that
  * builds on parent context. This component allows applications to build the
- * fields and options for events declaratively and through nesting.
+ * analytics and options for events declaratively and through nesting.
  */
 class TrackingProvider extends PureComponent {
     static propTypes = {
-        /** An object of event specific fields where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `fields` property. */
-        eventFields: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
+        /** An object of event specific analytics where the event name is the key and the value is an object of field key/value pairs for the event. Event specific values will be merged with defaults from the `analytics` property. */
+        eventAnalytics: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
         /** An object of event specific options where the event name is the key and the value is an object of option key/value pairs for the event. Event specific values will be merged with defaults from the `options` property. */
-        eventOptions: PropTypes.objectOf(PropTypes.objectOf(PropTypes.string)),
-        /** Object of string values that represents the default fields to apply to all events within this context. */
-        fields: PropTypes.objectOf(PropTypes.string),
+        eventOptions: PropTypes.objectOf(PropTypes.objectOf(PropTypes.any)),
+        /** Object of string values that represents the default analytics to apply to all events within this context. */
+        analytics: PropTypes.objectOf(PropTypes.any),
         /** The trigger options. */
-        options: PropTypes.objectOf(PropTypes.string),
+        options: PropTypes.objectOf(PropTypes.any),
         /** When true, overwrites the current context with specified properties. Default is to merge instead of overwrite. */
         overwrite: PropTypes.bool,
         /** Tracking event trigger implementation. */
@@ -50,9 +50,9 @@ class TrackingProvider extends PureComponent {
         // structure must mimic the one defined in TrackingContext;
         this.TrackingContext = {
             _data: {
-                eventFields: this.props.eventFields,
+                eventAnalytics: this.props.eventAnalytics,
                 eventOptions: this.props.eventOptions,
-                fields: this.props.fields,
+                analytics: this.props.analytics,
                 options: this.props.options,
                 trigger: this.props.trigger || (/* istanbul ignore next */() => {})
             },
@@ -66,28 +66,28 @@ class TrackingProvider extends PureComponent {
      *
      * @param {Object} data
      */
-    mergeContextData(data = {eventFields: {}, eventOptions: {}}) {
-        const {eventFields, eventOptions, fields, options, overwrite} = this.props;
+    mergeContextData(data = {eventAnalytics: {}, eventOptions: {}}) {
+        const {eventAnalytics, eventOptions, analytics, options, overwrite} = this.props;
         const newData = {};
 
         if (overwrite) {
-            newData.eventFields = eventFields || data.eventFields;
+            newData.eventAnalytics = eventAnalytics || data.eventAnalytics;
             newData.eventOptions = eventOptions || data.eventOptions;
-            newData.fields = fields || data.fields;
+            newData.analytics = analytics || data.analytics;
             newData.options = options || data.options;
         } else {
             // Not an overwrite so merge the properties and context objects
-            newData.eventFields = {...data.eventFields, ...eventFields};
+            newData.eventAnalytics = {...data.eventAnalytics, ...eventAnalytics};
             newData.eventOptions = {...data.eventOptions, ...eventOptions};
-            newData.fields = {...data.fields, ...fields};
+            newData.analytics = {...data.analytics, ...analytics};
             newData.options = {...data.options, ...options};
 
-            // if eventFields or eventOptions was specified need to do a shallow
+            // if eventAnalytics or eventOptions was specified need to do a shallow
             // copy and another shallow copy one level deep for each key.
 
-            if (eventFields) {
-                Object.keys(newData.eventFields).forEach((key) => {
-                    newData.eventFields[key] = {...data.eventFields[key], ...eventFields[key]};
+            if (eventAnalytics) {
+                Object.keys(newData.eventAnalytics).forEach((key) => {
+                    newData.eventAnalytics[key] = {...data.eventAnalytics[key], ...eventAnalytics[key]};
                 });
             }
             if (eventOptions) {
@@ -105,27 +105,27 @@ class TrackingProvider extends PureComponent {
      * values in context and then invokes the implementation specific trigger
      * method.
      */
-    trigger = (event, fields = {}, options = {}) => {
+    trigger = (event, analytics = {}, options = {}) => {
         const data = this.TrackingContext._data;
         const name = event || data.event;
-        const eventFields = data.eventFields ? data.eventFields[name] : {};
+        const eventAnalytics = data.eventAnalytics ? data.eventAnalytics[name] : {};
         const eventOptions = data.eventOptions ? data.eventOptions[name] : {};
 
         if (!name) {
             throw new TypeError('event is a required parameter');
         }
 
-        fields = {
-            ...data.fields,
-            ...eventFields,
-            ...fields
+        analytics = {
+            ...data.analytics,
+            ...eventAnalytics,
+            ...analytics
         };
         options = {
             ...data.options,
             ...eventOptions,
             ...options
         };
-        return data.trigger(name, fields, options);
+        return data.trigger(name, analytics, options);
     }
 
     /**

--- a/src/components/TrackingProvider/tests/TrackingProvider.test.js
+++ b/src/components/TrackingProvider/tests/TrackingProvider.test.js
@@ -20,7 +20,7 @@ import TrackingProvider from '../TrackingProvider.js';
 import sinon from 'sinon';
 
 const PROP_DATA = {
-    eventFields: {
+    eventAnalytics: {
         'datepicker.close': {
             'who': 'you'
         },
@@ -42,7 +42,7 @@ const PROP_DATA = {
             'pain': 'always'
         }
     },
-    fields: {
+    analytics: {
         'location': 'top',
         'action': 'test',
         'language': 'english'
@@ -54,7 +54,7 @@ const PROP_DATA = {
 };
 
 const CONTEXT_DATA = {
-    eventFields: {
+    eventAnalytics: {
         'datepicker.close': {
             'who': 'me'
         },
@@ -76,7 +76,7 @@ const CONTEXT_DATA = {
             'waitforever': 'sure'
         }
     },
-    fields: {
+    analytics: {
         'location': 'bottom',
         'action': 'failure',
         'zombie': 'walking'
@@ -88,14 +88,14 @@ const CONTEXT_DATA = {
 };
 
 const MERGED_DATA = {
-    eventFields: {...CONTEXT_DATA.eventFields, ...PROP_DATA.eventFields},
+    eventAnalytics: {...CONTEXT_DATA.eventAnalytics, ...PROP_DATA.eventAnalytics},
     eventOptions: {...CONTEXT_DATA.eventOptions, ...PROP_DATA.eventOptions},
-    fields: {...CONTEXT_DATA.fields, ...PROP_DATA.fields},
+    analytics: {...CONTEXT_DATA.analytics, ...PROP_DATA.analytics},
     options: {...CONTEXT_DATA.options, ...PROP_DATA.options}
 };
 
-Object.keys(MERGED_DATA.eventFields).forEach((key) => {
-    MERGED_DATA.eventFields[key] = {...CONTEXT_DATA.eventFields[key], ...PROP_DATA.eventFields[key]};
+Object.keys(MERGED_DATA.eventAnalytics).forEach((key) => {
+    MERGED_DATA.eventAnalytics[key] = {...CONTEXT_DATA.eventAnalytics[key], ...PROP_DATA.eventAnalytics[key]};
 });
 Object.keys(MERGED_DATA.eventOptions).forEach((key) => {
     MERGED_DATA.eventOptions[key] = {...CONTEXT_DATA.eventOptions[key], ...PROP_DATA.eventOptions[key]};
@@ -114,9 +114,9 @@ describe('<TrackingProvider/>', () => {
             const provider = shallow(<TrackingProvider />).instance();
             expect(provider.TrackingContext).to.deep.equal({
                 _data: {
-                    eventFields: undefined, // eslint-disable-line no-undefined
+                    eventAnalytics: undefined, // eslint-disable-line no-undefined
                     eventOptions: undefined, // eslint-disable-line no-undefined
-                    fields: undefined, // eslint-disable-line no-undefined
+                    analytics: undefined, // eslint-disable-line no-undefined
                     options: undefined, // eslint-disable-line no-undefined
                     trigger: provider.TrackingContext._data.trigger
                 },
@@ -129,7 +129,7 @@ describe('<TrackingProvider/>', () => {
         it('should initialize TrackingContext with specified properties', () => {
             const triggerStub = sinon.stub();
             const _data = {
-                eventFields: {
+                eventAnalytics: {
                     myEvent: {
                         one: 'one',
                         two: 'two'
@@ -140,7 +140,7 @@ describe('<TrackingProvider/>', () => {
                         three: 'four'
                     }
                 },
-                fields: {
+                analytics: {
                     five: 'six',
                     seven: 'eight'
                 },
@@ -161,7 +161,7 @@ describe('<TrackingProvider/>', () => {
         it('should initialize nested TrackingContext with specified properties', () => {
             const triggerStub = sinon.stub();
             const _data = {
-                eventFields: {
+                eventAnalytics: {
                     myEvent: {
                         one: 'one',
                         two: 'two'
@@ -172,7 +172,7 @@ describe('<TrackingProvider/>', () => {
                         three: 'three'
                     }
                 },
-                fields: {
+                analytics: {
                     five: 'five',
                     seven: 'seven'
                 },
@@ -183,7 +183,7 @@ describe('<TrackingProvider/>', () => {
             };
 
             const _data2 = {
-                eventFields: {
+                eventAnalytics: {
                     myEvent: {
                         one: 'one2',
                         three: 'three'
@@ -203,7 +203,7 @@ describe('<TrackingProvider/>', () => {
                         four: 'four'
                     }
                 },
-                fields: {
+                analytics: {
                     five: 'six2',
                     eight: 'eight'
                 },
@@ -216,10 +216,10 @@ describe('<TrackingProvider/>', () => {
             // This is ugly. Essentially need to deep merge to build the expected
             // data object but just doing this manually instead.
             const expectedData = JSON.parse(JSON.stringify(_data));
-            Object.assign(expectedData.eventFields.myEvent, _data2.eventFields.myEvent);
-            expectedData.eventFields.secondEvent = _data2.eventFields.secondEvent;
+            Object.assign(expectedData.eventAnalytics.myEvent, _data2.eventAnalytics.myEvent);
+            expectedData.eventAnalytics.secondEvent = _data2.eventAnalytics.secondEvent;
             Object.assign(expectedData.eventOptions, _data2.eventOptions);
-            Object.assign(expectedData.fields, _data2.fields);
+            Object.assign(expectedData.analytics, _data2.analytics);
             Object.assign(expectedData.options, _data2.options);
             // Should inherit the parent trigger method.
             expectedData.trigger = triggerStub;
@@ -293,14 +293,14 @@ describe('<TrackingProvider/>', () => {
             expect(provider.trigger).to.throw('event is a required parameter');
         });
 
-        it('should trigger an event with merged fields and options', () => {
+        it('should trigger an event with merged analytics and options', () => {
             const event = 'datepicker.close';
-            const provider = shallow(<TrackingProvider trigger={triggerSpy} eventFields={PROP_DATA.eventFields} eventOptions={PROP_DATA.eventOptions} fields={PROP_DATA.fields} options={PROP_DATA.options}/>).instance();
-            provider.trigger(event, CONTEXT_DATA.fields, CONTEXT_DATA.options);
+            const provider = shallow(<TrackingProvider trigger={triggerSpy} eventAnalytics={PROP_DATA.eventAnalytics} eventOptions={PROP_DATA.eventOptions} analytics={PROP_DATA.analytics} options={PROP_DATA.options}/>).instance();
+            provider.trigger(event, CONTEXT_DATA.analytics, CONTEXT_DATA.options);
             expect(triggerSpy.calledOnce).to.equal(true);
             const args = triggerSpy.args[0];
             expect(args[0]).to.equal(event);
-            expect(args[1]).to.deep.equal({...PROP_DATA.fields, ...PROP_DATA.eventFields[event], ...CONTEXT_DATA.fields});
+            expect(args[1]).to.deep.equal({...PROP_DATA.analytics, ...PROP_DATA.eventAnalytics[event], ...CONTEXT_DATA.analytics});
             expect(args[2]).to.deep.equal({...PROP_DATA.options, ...PROP_DATA.eventOptions[event], ...CONTEXT_DATA.options});
         });
     });
@@ -313,13 +313,13 @@ describe('<TrackingProvider/>', () => {
         });
 
         it('should set this.TrackingContext._data to context data when no data passed', () => {
-            const trackingProvider = shallow(<TrackingProvider trigger={triggerSpy} eventFields={PROP_DATA.eventFields} eventOptions={PROP_DATA.eventOptions} fields={PROP_DATA.fields} options={PROP_DATA.options}/>).instance();
+            const trackingProvider = shallow(<TrackingProvider trigger={triggerSpy} eventAnalytics={PROP_DATA.eventAnalytics} eventOptions={PROP_DATA.eventOptions} analytics={PROP_DATA.analytics} options={PROP_DATA.options}/>).instance();
             trackingProvider.renderProvider();
             expect(trackingProvider.TrackingContext._data).to.deep.equal({...PROP_DATA, trigger: triggerSpy});
         });
 
         it('should set this.TrackingContext._data to merge of context data', () => {
-            const trackingProvider = shallow(<TrackingProvider trigger={triggerSpy} eventFields={PROP_DATA.eventFields} eventOptions={PROP_DATA.eventOptions} fields={PROP_DATA.fields} options={PROP_DATA.options}/>).instance();
+            const trackingProvider = shallow(<TrackingProvider trigger={triggerSpy} eventAnalytics={PROP_DATA.eventAnalytics} eventOptions={PROP_DATA.eventOptions} analytics={PROP_DATA.analytics} options={PROP_DATA.options}/>).instance();
             trackingProvider.renderProvider({_data: CONTEXT_DATA});
             expect(trackingProvider.TrackingContext._data).to.deep.equal({...MERGED_DATA, trigger: triggerSpy});
         });

--- a/src/components/TrackingProvider/tests/TrackingProvider.test.js
+++ b/src/components/TrackingProvider/tests/TrackingProvider.test.js
@@ -53,6 +53,90 @@ const PROP_DATA = {
     }
 };
 
+const PROP_DATA_FIELDS = {
+    eventFields: {
+        'datepicker.close': {
+            'who': 'you'
+        },
+        'datepicker.open': {
+            'who': 'you'
+        },
+        'datepicker.blur': {
+            'when': 'today'
+        }
+    },
+    eventOptions: {
+        'datepicker.close': {
+            'doitnow': 'yes'
+        },
+        'datepicker.open': {
+            'doitnow': 'yes'
+        },
+        'datepicker.perf': {
+            'pain': 'always'
+        }
+    },
+    fields: {
+        'location': 'top',
+        'action': 'test',
+        'language': 'english'
+    },
+    options: {
+        'delay': '100',
+        'jump': 'yolo'
+    }
+};
+
+const PROP_DATA_FIELDS_PAYLOAD = {
+    eventFields: {
+        'datepicker.close': {
+            'who': 'not you'
+        },
+        'datepicker.open': {
+            'who': 'not you'
+        },
+        'datepicker.blur': {
+            'when': 'not today'
+        }
+    },
+    eventPayload: {
+        'datepicker.close': {
+            'who': 'you'
+        },
+        'datepicker.open': {
+            'who': 'you'
+        },
+        'datepicker.blur': {
+            'when': 'today'
+        }
+    },
+    eventOptions: {
+        'datepicker.close': {
+            'doitnow': 'yes'
+        },
+        'datepicker.open': {
+            'doitnow': 'yes'
+        },
+        'datepicker.perf': {
+            'pain': 'always'
+        }
+    },
+    fields: {
+        'location': 'bottom',
+        'action': 'test2',
+        'language': 'french'
+    },
+    payload: {
+        'location': 'top',
+        'action': 'test',
+        'language': 'english'
+    },
+    options: {
+        'delay': '100',
+        'jump': 'yolo'
+    }
+};
+
 const CONTEXT_DATA = {
     eventPayload: {
         'datepicker.close': {
@@ -75,6 +159,90 @@ const CONTEXT_DATA = {
         'generic.event': {
             'waitforever': 'sure'
         }
+    },
+    payload: {
+        'location': 'bottom',
+        'action': 'failure',
+        'zombie': 'walking'
+    },
+    options: {
+        'delay': '404',
+        'up': 'down'
+    }
+};
+
+const CONTEXT_DATA_FIELDS = {
+    eventFields: {
+        'datepicker.close': {
+            'who': 'me'
+        },
+        'datepicker.open': {
+            'who': 'me'
+        },
+        'generic.click': {
+            'dummy': 'ohyeah'
+        }
+    },
+    eventOptions: {
+        'datepicker.close': {
+            'doitnow': 'no'
+        },
+        'datepicker.open': {
+            'doitnow': 'no'
+        },
+        'generic.event': {
+            'waitforever': 'sure'
+        }
+    },
+    fields: {
+        'location': 'bottom',
+        'action': 'failure',
+        'zombie': 'walking'
+    },
+    options: {
+        'delay': '404',
+        'up': 'down'
+    }
+};
+
+const CONTEXT_DATA_FIELDS_PAYLOAD = {
+    eventFields: {
+        'datepicker.close': {
+            'who': 'not me'
+        },
+        'datepicker.open': {
+            'who': 'not me'
+        },
+        'generic.click': {
+            'dummy': 'not ohyeah'
+        }
+    },
+    eventPayload: {
+        'datepicker.close': {
+            'who': 'me'
+        },
+        'datepicker.open': {
+            'who': 'me'
+        },
+        'generic.click': {
+            'dummy': 'ohyeah'
+        }
+    },
+    eventOptions: {
+        'datepicker.close': {
+            'doitnow': 'no'
+        },
+        'datepicker.open': {
+            'doitnow': 'no'
+        },
+        'generic.event': {
+            'waitforever': 'sure'
+        }
+    },
+    fields: {
+        'location': 'top',
+        'action': 'success',
+        'zombie': 'running'
     },
     payload: {
         'location': 'bottom',
@@ -256,9 +424,21 @@ describe('<TrackingProvider/>', () => {
             expect(result).to.deep.equal(PROP_DATA);
         });
 
+        it('should return the specified properties as the data if overwrite is true even when using fields instead of payload', () => {
+            const provider = shallow(<TrackingProvider {...PROP_DATA_FIELDS} overwrite/>).instance();
+            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS);
+            expect(result).to.deep.equal(PROP_DATA); // Everything gets mapped back from eventFields/fields to eventPayload/payload
+        });
+
         it('should return the context data if no data properties specified and overwrite is true', () => {
             const provider = shallow(<TrackingProvider overwrite/>).instance();
             const result = provider.mergeContextData(CONTEXT_DATA);
+            expect(result).to.deep.equal(CONTEXT_DATA);
+        });
+
+        it('should return the context data if no data properties specified and overwrite is true even when using fields instead of payload', () => {
+            const provider = shallow(<TrackingProvider overwrite/>).instance();
+            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS);
             expect(result).to.deep.equal(CONTEXT_DATA);
         });
 
@@ -268,9 +448,33 @@ describe('<TrackingProvider/>', () => {
             expect(result).to.deep.equal(CONTEXT_DATA);
         });
 
+        it('should return the context data if no data properties specified and overwrite is false even when using fields instead of payload', () => {
+            const provider = shallow(<TrackingProvider/>).instance();
+            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS);
+            expect(result).to.deep.equal(CONTEXT_DATA);
+        });
+
         it('should return a merge of the specified properties and data if overwrite is false', () => {
             const provider = shallow(<TrackingProvider {...PROP_DATA}/>).instance();
             const result = provider.mergeContextData(CONTEXT_DATA);
+            expect(result).to.deep.equal(MERGED_DATA);
+        });
+
+        it('should return a merge of the specified properties and data if overwrite is false even when using fields instead of payload', () => {
+            const provider = shallow(<TrackingProvider {...PROP_DATA_FIELDS}/>).instance();
+            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS);
+            expect(result).to.deep.equal(MERGED_DATA);
+        });
+
+        it('should prefer payload over fields if overwrite is true', () => {
+            const provider = shallow(<TrackingProvider {...PROP_DATA_FIELDS_PAYLOAD} overwrite/>).instance();
+            const result = provider.mergeContextData(CONTEXT_DATA);
+            expect(result).to.deep.equal(PROP_DATA);
+        });
+
+        it('should prefer payload over fields if overwrite is false', () => {
+            const provider = shallow(<TrackingProvider {...PROP_DATA_FIELDS_PAYLOAD}/>).instance();
+            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS_PAYLOAD);
             expect(result).to.deep.equal(MERGED_DATA);
         });
 

--- a/src/components/TrackingProvider/tests/TrackingProvider.test.js
+++ b/src/components/TrackingProvider/tests/TrackingProvider.test.js
@@ -364,12 +364,6 @@ describe('<TrackingProvider/>', () => {
             expect(result).to.deep.equal(CONTEXT_DATA);
         });
 
-        it('should return the context data if no data properties specified and overwrite is false even when using fields instead of payload', () => {
-            const provider = shallow(<TrackingProvider/>).instance();
-            const result = provider.mergeContextData(CONTEXT_DATA);
-            expect(result).to.deep.equal(CONTEXT_DATA);
-        });
-
         it('should return a merge of the specified properties and data if overwrite is false', () => {
             const provider = shallow(<TrackingProvider {...PROP_DATA}/>).instance();
             const result = provider.mergeContextData(CONTEXT_DATA);

--- a/src/components/TrackingProvider/tests/TrackingProvider.test.js
+++ b/src/components/TrackingProvider/tests/TrackingProvider.test.js
@@ -20,7 +20,7 @@ import TrackingProvider from '../TrackingProvider.js';
 import sinon from 'sinon';
 
 const PROP_DATA = {
-    eventAnalytics: {
+    eventPayload: {
         'datepicker.close': {
             'who': 'you'
         },
@@ -42,7 +42,7 @@ const PROP_DATA = {
             'pain': 'always'
         }
     },
-    analytics: {
+    payload: {
         'location': 'top',
         'action': 'test',
         'language': 'english'
@@ -54,7 +54,7 @@ const PROP_DATA = {
 };
 
 const CONTEXT_DATA = {
-    eventAnalytics: {
+    eventPayload: {
         'datepicker.close': {
             'who': 'me'
         },
@@ -76,7 +76,7 @@ const CONTEXT_DATA = {
             'waitforever': 'sure'
         }
     },
-    analytics: {
+    payload: {
         'location': 'bottom',
         'action': 'failure',
         'zombie': 'walking'
@@ -88,14 +88,14 @@ const CONTEXT_DATA = {
 };
 
 const MERGED_DATA = {
-    eventAnalytics: {...CONTEXT_DATA.eventAnalytics, ...PROP_DATA.eventAnalytics},
+    eventPayload: {...CONTEXT_DATA.eventPayload, ...PROP_DATA.eventPayload},
     eventOptions: {...CONTEXT_DATA.eventOptions, ...PROP_DATA.eventOptions},
-    analytics: {...CONTEXT_DATA.analytics, ...PROP_DATA.analytics},
+    payload: {...CONTEXT_DATA.payload, ...PROP_DATA.payload},
     options: {...CONTEXT_DATA.options, ...PROP_DATA.options}
 };
 
-Object.keys(MERGED_DATA.eventAnalytics).forEach((key) => {
-    MERGED_DATA.eventAnalytics[key] = {...CONTEXT_DATA.eventAnalytics[key], ...PROP_DATA.eventAnalytics[key]};
+Object.keys(MERGED_DATA.eventPayload).forEach((key) => {
+    MERGED_DATA.eventPayload[key] = {...CONTEXT_DATA.eventPayload[key], ...PROP_DATA.eventPayload[key]};
 });
 Object.keys(MERGED_DATA.eventOptions).forEach((key) => {
     MERGED_DATA.eventOptions[key] = {...CONTEXT_DATA.eventOptions[key], ...PROP_DATA.eventOptions[key]};
@@ -114,9 +114,9 @@ describe('<TrackingProvider/>', () => {
             const provider = shallow(<TrackingProvider />).instance();
             expect(provider.TrackingContext).to.deep.equal({
                 _data: {
-                    eventAnalytics: undefined, // eslint-disable-line no-undefined
+                    eventPayload: undefined, // eslint-disable-line no-undefined
                     eventOptions: undefined, // eslint-disable-line no-undefined
-                    analytics: undefined, // eslint-disable-line no-undefined
+                    payload: undefined, // eslint-disable-line no-undefined
                     options: undefined, // eslint-disable-line no-undefined
                     trigger: provider.TrackingContext._data.trigger
                 },
@@ -129,7 +129,7 @@ describe('<TrackingProvider/>', () => {
         it('should initialize TrackingContext with specified properties', () => {
             const triggerStub = sinon.stub();
             const _data = {
-                eventAnalytics: {
+                eventPayload: {
                     myEvent: {
                         one: 'one',
                         two: 'two'
@@ -140,7 +140,7 @@ describe('<TrackingProvider/>', () => {
                         three: 'four'
                     }
                 },
-                analytics: {
+                payload: {
                     five: 'six',
                     seven: 'eight'
                 },
@@ -161,7 +161,7 @@ describe('<TrackingProvider/>', () => {
         it('should initialize nested TrackingContext with specified properties', () => {
             const triggerStub = sinon.stub();
             const _data = {
-                eventAnalytics: {
+                eventPayload: {
                     myEvent: {
                         one: 'one',
                         two: 'two'
@@ -172,7 +172,7 @@ describe('<TrackingProvider/>', () => {
                         three: 'three'
                     }
                 },
-                analytics: {
+                payload: {
                     five: 'five',
                     seven: 'seven'
                 },
@@ -183,7 +183,7 @@ describe('<TrackingProvider/>', () => {
             };
 
             const _data2 = {
-                eventAnalytics: {
+                eventPayload: {
                     myEvent: {
                         one: 'one2',
                         three: 'three'
@@ -203,7 +203,7 @@ describe('<TrackingProvider/>', () => {
                         four: 'four'
                     }
                 },
-                analytics: {
+                payload: {
                     five: 'six2',
                     eight: 'eight'
                 },
@@ -216,10 +216,10 @@ describe('<TrackingProvider/>', () => {
             // This is ugly. Essentially need to deep merge to build the expected
             // data object but just doing this manually instead.
             const expectedData = JSON.parse(JSON.stringify(_data));
-            Object.assign(expectedData.eventAnalytics.myEvent, _data2.eventAnalytics.myEvent);
-            expectedData.eventAnalytics.secondEvent = _data2.eventAnalytics.secondEvent;
+            Object.assign(expectedData.eventPayload.myEvent, _data2.eventPayload.myEvent);
+            expectedData.eventPayload.secondEvent = _data2.eventPayload.secondEvent;
             Object.assign(expectedData.eventOptions, _data2.eventOptions);
-            Object.assign(expectedData.analytics, _data2.analytics);
+            Object.assign(expectedData.payload, _data2.payload);
             Object.assign(expectedData.options, _data2.options);
             // Should inherit the parent trigger method.
             expectedData.trigger = triggerStub;
@@ -293,14 +293,14 @@ describe('<TrackingProvider/>', () => {
             expect(provider.trigger).to.throw('event is a required parameter');
         });
 
-        it('should trigger an event with merged analytics and options', () => {
+        it('should trigger an event with merged payload and options', () => {
             const event = 'datepicker.close';
-            const provider = shallow(<TrackingProvider trigger={triggerSpy} eventAnalytics={PROP_DATA.eventAnalytics} eventOptions={PROP_DATA.eventOptions} analytics={PROP_DATA.analytics} options={PROP_DATA.options}/>).instance();
-            provider.trigger(event, CONTEXT_DATA.analytics, CONTEXT_DATA.options);
+            const provider = shallow(<TrackingProvider trigger={triggerSpy} eventPayload={PROP_DATA.eventPayload} eventOptions={PROP_DATA.eventOptions} payload={PROP_DATA.payload} options={PROP_DATA.options}/>).instance();
+            provider.trigger(event, CONTEXT_DATA.payload, CONTEXT_DATA.options);
             expect(triggerSpy.calledOnce).to.equal(true);
             const args = triggerSpy.args[0];
             expect(args[0]).to.equal(event);
-            expect(args[1]).to.deep.equal({...PROP_DATA.analytics, ...PROP_DATA.eventAnalytics[event], ...CONTEXT_DATA.analytics});
+            expect(args[1]).to.deep.equal({...PROP_DATA.payload, ...PROP_DATA.eventPayload[event], ...CONTEXT_DATA.payload});
             expect(args[2]).to.deep.equal({...PROP_DATA.options, ...PROP_DATA.eventOptions[event], ...CONTEXT_DATA.options});
         });
     });
@@ -313,13 +313,13 @@ describe('<TrackingProvider/>', () => {
         });
 
         it('should set this.TrackingContext._data to context data when no data passed', () => {
-            const trackingProvider = shallow(<TrackingProvider trigger={triggerSpy} eventAnalytics={PROP_DATA.eventAnalytics} eventOptions={PROP_DATA.eventOptions} analytics={PROP_DATA.analytics} options={PROP_DATA.options}/>).instance();
+            const trackingProvider = shallow(<TrackingProvider trigger={triggerSpy} eventPayload={PROP_DATA.eventPayload} eventOptions={PROP_DATA.eventOptions} payload={PROP_DATA.payload} options={PROP_DATA.options}/>).instance();
             trackingProvider.renderProvider();
             expect(trackingProvider.TrackingContext._data).to.deep.equal({...PROP_DATA, trigger: triggerSpy});
         });
 
         it('should set this.TrackingContext._data to merge of context data', () => {
-            const trackingProvider = shallow(<TrackingProvider trigger={triggerSpy} eventAnalytics={PROP_DATA.eventAnalytics} eventOptions={PROP_DATA.eventOptions} analytics={PROP_DATA.analytics} options={PROP_DATA.options}/>).instance();
+            const trackingProvider = shallow(<TrackingProvider trigger={triggerSpy} eventPayload={PROP_DATA.eventPayload} eventOptions={PROP_DATA.eventOptions} payload={PROP_DATA.payload} options={PROP_DATA.options}/>).instance();
             trackingProvider.renderProvider({_data: CONTEXT_DATA});
             expect(trackingProvider.TrackingContext._data).to.deep.equal({...MERGED_DATA, trigger: triggerSpy});
         });

--- a/src/components/TrackingProvider/tests/TrackingProvider.test.js
+++ b/src/components/TrackingProvider/tests/TrackingProvider.test.js
@@ -171,90 +171,6 @@ const CONTEXT_DATA = {
     }
 };
 
-const CONTEXT_DATA_FIELDS = {
-    eventFields: {
-        'datepicker.close': {
-            'who': 'me'
-        },
-        'datepicker.open': {
-            'who': 'me'
-        },
-        'generic.click': {
-            'dummy': 'ohyeah'
-        }
-    },
-    eventOptions: {
-        'datepicker.close': {
-            'doitnow': 'no'
-        },
-        'datepicker.open': {
-            'doitnow': 'no'
-        },
-        'generic.event': {
-            'waitforever': 'sure'
-        }
-    },
-    fields: {
-        'location': 'bottom',
-        'action': 'failure',
-        'zombie': 'walking'
-    },
-    options: {
-        'delay': '404',
-        'up': 'down'
-    }
-};
-
-const CONTEXT_DATA_FIELDS_PAYLOAD = {
-    eventFields: {
-        'datepicker.close': {
-            'who': 'not me'
-        },
-        'datepicker.open': {
-            'who': 'not me'
-        },
-        'generic.click': {
-            'dummy': 'not ohyeah'
-        }
-    },
-    eventPayload: {
-        'datepicker.close': {
-            'who': 'me'
-        },
-        'datepicker.open': {
-            'who': 'me'
-        },
-        'generic.click': {
-            'dummy': 'ohyeah'
-        }
-    },
-    eventOptions: {
-        'datepicker.close': {
-            'doitnow': 'no'
-        },
-        'datepicker.open': {
-            'doitnow': 'no'
-        },
-        'generic.event': {
-            'waitforever': 'sure'
-        }
-    },
-    fields: {
-        'location': 'top',
-        'action': 'success',
-        'zombie': 'running'
-    },
-    payload: {
-        'location': 'bottom',
-        'action': 'failure',
-        'zombie': 'walking'
-    },
-    options: {
-        'delay': '404',
-        'up': 'down'
-    }
-};
-
 const MERGED_DATA = {
     eventPayload: {...CONTEXT_DATA.eventPayload, ...PROP_DATA.eventPayload},
     eventOptions: {...CONTEXT_DATA.eventOptions, ...PROP_DATA.eventOptions},
@@ -426,7 +342,7 @@ describe('<TrackingProvider/>', () => {
 
         it('should return the specified properties as the data if overwrite is true even when using fields instead of payload', () => {
             const provider = shallow(<TrackingProvider {...PROP_DATA_FIELDS} overwrite/>).instance();
-            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS);
+            const result = provider.mergeContextData(CONTEXT_DATA);
             expect(result).to.deep.equal(PROP_DATA); // Everything gets mapped back from eventFields/fields to eventPayload/payload
         });
 
@@ -438,7 +354,7 @@ describe('<TrackingProvider/>', () => {
 
         it('should return the context data if no data properties specified and overwrite is true even when using fields instead of payload', () => {
             const provider = shallow(<TrackingProvider overwrite/>).instance();
-            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS);
+            const result = provider.mergeContextData(CONTEXT_DATA);
             expect(result).to.deep.equal(CONTEXT_DATA);
         });
 
@@ -450,7 +366,7 @@ describe('<TrackingProvider/>', () => {
 
         it('should return the context data if no data properties specified and overwrite is false even when using fields instead of payload', () => {
             const provider = shallow(<TrackingProvider/>).instance();
-            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS);
+            const result = provider.mergeContextData(CONTEXT_DATA);
             expect(result).to.deep.equal(CONTEXT_DATA);
         });
 
@@ -462,7 +378,7 @@ describe('<TrackingProvider/>', () => {
 
         it('should return a merge of the specified properties and data if overwrite is false even when using fields instead of payload', () => {
             const provider = shallow(<TrackingProvider {...PROP_DATA_FIELDS}/>).instance();
-            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS);
+            const result = provider.mergeContextData(CONTEXT_DATA);
             expect(result).to.deep.equal(MERGED_DATA);
         });
 
@@ -474,7 +390,7 @@ describe('<TrackingProvider/>', () => {
 
         it('should prefer payload over fields if overwrite is false', () => {
             const provider = shallow(<TrackingProvider {...PROP_DATA_FIELDS_PAYLOAD}/>).instance();
-            const result = provider.mergeContextData(CONTEXT_DATA_FIELDS_PAYLOAD);
+            const result = provider.mergeContextData(CONTEXT_DATA);
             expect(result).to.deep.equal(MERGED_DATA);
         });
 

--- a/src/components/TrackingTrigger/TrackingTrigger.js
+++ b/src/components/TrackingTrigger/TrackingTrigger.js
@@ -25,8 +25,8 @@ class TrackingTrigger extends PureComponent {
     static propTypes = {
         /** The event to trigger. */
         event: PropTypes.string.isRequired,
-        /** The event specific analytics. */
-        analytics: PropTypes.objectOf(PropTypes.any),
+        /** The event specific payload. */
+        payload: PropTypes.objectOf(PropTypes.any),
         /** Callback function invoked after the event successfully triggered. */
         onTrigger: PropTypes.func,
         /** Trigger options. */
@@ -34,15 +34,15 @@ class TrackingTrigger extends PureComponent {
     };
 
     static defaultProps = {
-        analytics: {},
+        payload: {},
         onTrigger: () => {},
         options: {}
     };
 
     componentDidMount() {
-        const {event, analytics, onTrigger, options} = this.props;
+        const {event, payload, onTrigger, options} = this.props;
         if (typeof this.trigger === 'function') {
-            const triggerContext = this.trigger(event, analytics, options);
+            const triggerContext = this.trigger(event, payload, options);
             onTrigger(triggerContext);
         }
     }

--- a/src/components/TrackingTrigger/TrackingTrigger.js
+++ b/src/components/TrackingTrigger/TrackingTrigger.js
@@ -25,6 +25,8 @@ class TrackingTrigger extends PureComponent {
     static propTypes = {
         /** The event to trigger. */
         event: PropTypes.string.isRequired,
+        /** (Deprecated) The event specific fields. */
+        fields: PropTypes.objectOf(PropTypes.string),
         /** The event specific payload. */
         payload: PropTypes.objectOf(PropTypes.any),
         /** Callback function invoked after the event successfully triggered. */
@@ -34,13 +36,15 @@ class TrackingTrigger extends PureComponent {
     };
 
     static defaultProps = {
-        payload: {},
         onTrigger: () => {},
         options: {}
     };
 
     componentDidMount() {
-        const {event, payload, onTrigger, options} = this.props;
+        const {event, fields, onTrigger, options} = this.props;
+        let {payload} = this.props;
+        payload = payload || fields || {};
+
         if (typeof this.trigger === 'function') {
             const triggerContext = this.trigger(event, payload, options);
             onTrigger(triggerContext);
@@ -53,7 +57,7 @@ class TrackingTrigger extends PureComponent {
         // Save a reference to the trigger method for use in componentDidMount.
         this.trigger = trigger;
         return children;
-    }
+    };
 
     render() {
         return (

--- a/src/components/TrackingTrigger/TrackingTrigger.js
+++ b/src/components/TrackingTrigger/TrackingTrigger.js
@@ -25,7 +25,7 @@ class TrackingTrigger extends PureComponent {
     static propTypes = {
         /** The event to trigger. */
         event: PropTypes.string.isRequired,
-        /** (Deprecated) The event specific fields. */
+        /** (Deprecated) The event specific fields. The `payload` property takes precedence over this property if both are specified. */
         fields: PropTypes.objectOf(PropTypes.string),
         /** The event specific payload. */
         payload: PropTypes.objectOf(PropTypes.any),

--- a/src/components/TrackingTrigger/TrackingTrigger.js
+++ b/src/components/TrackingTrigger/TrackingTrigger.js
@@ -25,8 +25,8 @@ class TrackingTrigger extends PureComponent {
     static propTypes = {
         /** The event to trigger. */
         event: PropTypes.string.isRequired,
-        /** The event specific fields. */
-        fields: PropTypes.objectOf(PropTypes.string),
+        /** The event specific analytics. */
+        analytics: PropTypes.objectOf(PropTypes.any),
         /** Callback function invoked after the event successfully triggered. */
         onTrigger: PropTypes.func,
         /** Trigger options. */
@@ -34,15 +34,15 @@ class TrackingTrigger extends PureComponent {
     };
 
     static defaultProps = {
-        fields: {},
+        analytics: {},
         onTrigger: () => {},
         options: {}
     };
 
     componentDidMount() {
-        const {event, fields, onTrigger, options} = this.props;
+        const {event, analytics, onTrigger, options} = this.props;
         if (typeof this.trigger === 'function') {
-            const triggerContext = this.trigger(event, fields, options);
+            const triggerContext = this.trigger(event, analytics, options);
             onTrigger(triggerContext);
         }
     }

--- a/src/components/TrackingTrigger/tests/TrackingTrigger.test.js
+++ b/src/components/TrackingTrigger/tests/TrackingTrigger.test.js
@@ -37,21 +37,21 @@ describe('<TrackingTrigger/>', () => {
             expect(triggerSpy.calledWith(event)).to.equal(true);
         });
 
-        it('should trigger the specified event, fields and options', () => {
+        it('should trigger the specified event, analytics and options', () => {
             const event = 'use.force';
-            const fields = {
+            const analytics = {
                 luke: 'yes',
                 padme: 'no'
             };
             const options = {
                 darkside: 'no'
             };
-            const trigger = shallow(<TrackingTrigger event={event} fields={fields} options={options}/>).instance();
+            const trigger = shallow(<TrackingTrigger event={event} analytics={analytics} options={options}/>).instance();
             const triggerSpy = sinon.spy();
             trigger.trigger = triggerSpy;
             trigger.componentDidMount();
             expect(triggerSpy.called).to.equal(true);
-            expect(triggerSpy.calledWith(event, fields, options)).to.equal(true);
+            expect(triggerSpy.calledWith(event, analytics, options)).to.equal(true);
         });
 
         it('should call the onTrigger callback with the specified event', () => {
@@ -66,9 +66,9 @@ describe('<TrackingTrigger/>', () => {
             expect(triggerSpy.calledWith({event})).to.equal(true);
         });
 
-        it('should call the onTrigger callback with the specified event, fields and options', () => {
+        it('should call the onTrigger callback with the specified event, analytics and options', () => {
             const event = 'use.force';
-            const fields = {
+            const analytics = {
                 luke: 'yes',
                 padme: 'no'
             };
@@ -76,17 +76,17 @@ describe('<TrackingTrigger/>', () => {
                 darkside: 'no'
             };
             const triggerSpy = sinon.spy();
-            const trigger = shallow(<TrackingTrigger event={event} fields={fields} options={options} onTrigger={triggerSpy}/>).instance();
+            const trigger = shallow(<TrackingTrigger event={event} analytics={analytics} options={options} onTrigger={triggerSpy}/>).instance();
             trigger.trigger = () => {
                 return {
                     event,
-                    fields,
+                    analytics,
                     options
                 };
             };
             trigger.componentDidMount();
             expect(triggerSpy.called).to.equal(true);
-            expect(triggerSpy.calledWith({event, fields, options})).to.equal(true);
+            expect(triggerSpy.calledWith({event, analytics, options})).to.equal(true);
         });
     });
 

--- a/src/components/TrackingTrigger/tests/TrackingTrigger.test.js
+++ b/src/components/TrackingTrigger/tests/TrackingTrigger.test.js
@@ -37,21 +37,21 @@ describe('<TrackingTrigger/>', () => {
             expect(triggerSpy.calledWith(event)).to.equal(true);
         });
 
-        it('should trigger the specified event, analytics and options', () => {
+        it('should trigger the specified event, payload and options', () => {
             const event = 'use.force';
-            const analytics = {
+            const payload = {
                 luke: 'yes',
                 padme: 'no'
             };
             const options = {
                 darkside: 'no'
             };
-            const trigger = shallow(<TrackingTrigger event={event} analytics={analytics} options={options}/>).instance();
+            const trigger = shallow(<TrackingTrigger event={event} payload={payload} options={options}/>).instance();
             const triggerSpy = sinon.spy();
             trigger.trigger = triggerSpy;
             trigger.componentDidMount();
             expect(triggerSpy.called).to.equal(true);
-            expect(triggerSpy.calledWith(event, analytics, options)).to.equal(true);
+            expect(triggerSpy.calledWith(event, payload, options)).to.equal(true);
         });
 
         it('should call the onTrigger callback with the specified event', () => {
@@ -66,9 +66,9 @@ describe('<TrackingTrigger/>', () => {
             expect(triggerSpy.calledWith({event})).to.equal(true);
         });
 
-        it('should call the onTrigger callback with the specified event, analytics and options', () => {
+        it('should call the onTrigger callback with the specified event, payload and options', () => {
             const event = 'use.force';
-            const analytics = {
+            const payload = {
                 luke: 'yes',
                 padme: 'no'
             };
@@ -76,17 +76,17 @@ describe('<TrackingTrigger/>', () => {
                 darkside: 'no'
             };
             const triggerSpy = sinon.spy();
-            const trigger = shallow(<TrackingTrigger event={event} analytics={analytics} options={options} onTrigger={triggerSpy}/>).instance();
+            const trigger = shallow(<TrackingTrigger event={event} payload={payload} options={options} onTrigger={triggerSpy}/>).instance();
             trigger.trigger = () => {
                 return {
                     event,
-                    analytics,
+                    payload,
                     options
                 };
             };
             trigger.componentDidMount();
             expect(triggerSpy.called).to.equal(true);
-            expect(triggerSpy.calledWith({event, analytics, options})).to.equal(true);
+            expect(triggerSpy.calledWith({event, payload, options})).to.equal(true);
         });
     });
 

--- a/src/components/TrackingTrigger/tests/TrackingTrigger.test.js
+++ b/src/components/TrackingTrigger/tests/TrackingTrigger.test.js
@@ -54,6 +54,23 @@ describe('<TrackingTrigger/>', () => {
             expect(triggerSpy.calledWith(event, payload, options)).to.equal(true);
         });
 
+        it('should trigger the specified event, fields (deprecated but falling back) and options', () => {
+            const event = 'use.force';
+            const fields = {
+                luke: 'yes',
+                padme: 'no'
+            };
+            const options = {
+                darkside: 'no'
+            };
+            const trigger = shallow(<TrackingTrigger event={event} fields={fields} options={options}/>).instance();
+            const triggerSpy = sinon.spy();
+            trigger.trigger = triggerSpy;
+            trigger.componentDidMount();
+            expect(triggerSpy.called).to.equal(true);
+            expect(triggerSpy.calledWith(event, fields, options)).to.equal(true);
+        });
+
         it('should call the onTrigger callback with the specified event', () => {
             const event = 'use.force';
             const triggerSpy = sinon.spy();

--- a/src/context/TrackingContext.js
+++ b/src/context/TrackingContext.js
@@ -22,9 +22,9 @@ import React from 'react';
  */
 const context = {
     _data: { // Intended for private use only
-        eventAnalytics: {},
+        eventPayload: {},
         eventOptions: {},
-        analytics: {},
+        payload: {},
         options: {},
         // The original trigger implementation passed in to TrackingProvider
         trigger: null

--- a/src/context/TrackingContext.js
+++ b/src/context/TrackingContext.js
@@ -22,9 +22,9 @@ import React from 'react';
  */
 const context = {
     _data: { // Intended for private use only
-        eventFields: {},
+        eventAnalytics: {},
         eventOptions: {},
-        fields: {},
+        analytics: {},
         options: {},
         // The original trigger implementation passed in to TrackingProvider
         trigger: null


### PR DESCRIPTION
### Description

- Added new `payload` and `eventPayload` properties which accept any formatted data object. `fields` and `eventFields` are marked deprecated and will only be used if `payload` / `eventPayload` not specified.
- Update the options object so the values can be any rather than just strings.

### How to Test

`npm run test`

### PR Author Checklist

- [ ] GitHub ISSUE LINKED
- [ ] Github Issue number & title in PR title (`ISSUE-XXXX: Ticket title`)
- [ ] Cross Browser tested if necessary
- [ ] Unit tests written (if necessary) and `npm test` passing locally
- [ ] Unit test coverage not decreased for any touched files
- [ ] Conflicts resolved
- [ ] PR Assigned to code reviewer

### Reviewer Checklist

- [ ] Tested locally
- [ ] Validated against ISSUE description
- [ ] Verified author checklist
- [ ] CI build/test passed and reported back green.
